### PR TITLE
Added a check for the linux install script to make it fail/exit early if skm/splashkit dependencies are missing. 

### DIFF
--- a/install-scripts/linux-install.sh
+++ b/install-scripts/linux-install.sh
@@ -4,9 +4,9 @@ GIT_LINUX_REPO=https://github.com/splashkit/splashkit-linux
 HOME_PATH=~
 INSTALL_PATH="${HOME_PATH}/.splashkit"
 
-command -v git >/dev/null 2>&1 || { echo "Please install git using your package manager For example: sudo apt install git" >&2; exit;}
+DEPENDENCIES=("libsdl2-dev" "libsdl2-gfx-dev" "libsdl2-mixer-dev" "libsdl2-ttf-dev" "libsdl2-net-dev" "libsdl2-image-dev" "libncurses5-dev" "libpng-dev" "libcurl4-openssl-dev")
 
-git clone --depth 1 --branch master $GIT_LINUX_REPO "${INSTALL_PATH}"
+command -v git >/dev/null 2>&1 || { echo "Please install git using your package manager For example: sudo apt install git" >&2; exit;}
 
 # Add SKM app to path without needing sudo
 echo "SKM and SplashKit depends on the following libraries:
@@ -23,8 +23,17 @@ echo "SKM and SplashKit depends on the following libraries:
 
     Please ensure these dependencies are installed using your package manager.
     For example:
-    sduo apt install libsdl2-dev libsdl2-gfx-dev libsdl2-mixer-dev libsdl2-ttf-dev libsdl2-net-dev libsdl2-image-dev libncurses-dev libpng-dev libcurl4-openssl-dev 
+    sudo apt install libsdl2-dev libsdl2-gfx-dev libsdl2-mixer-dev libsdl2-ttf-dev libsdl2-net-dev libsdl2-image-dev libncurses-dev libpng-dev libcurl4-openssl-dev 
     "
+
+for dependency in DEPENDENCIES; do
+    dpkg -l | grep "$dependency" > /dev/null 2>&1 || {
+        echo "$dependency is required for SKM and SplashKit. Please install $dependency and run the installer again."
+        exit;
+    }
+done
+
+git clone --depth 1 --branch master $GIT_LINUX_REPO "${INSTALL_PATH}"
 
 echo "
 SKM and SplashKit has been installed. please ensure SKM is added to the PATH.


### PR DESCRIPTION
Ubuntu 16.10 installs explicit libncurses version when executing ```sudo apt install libncurses-dev``` so I used an explicit version/package name and libncurses5-dev is supported at least as far back as Ubuntu 12.04 LTS.