### PR TITLE
ENHANCE: Don't append success message on commands

### DIFF
--- a/skm
+++ b/skm
@@ -12,9 +12,7 @@ if [ -f "$APP_PATH/$1/$1.sh" ] ; then
     COMMAND=$1
     shift
     "$APP_PATH/$COMMAND/$COMMAND.sh" $*
-    if [ $? -eq 0 ]; then
-        echo "🎉  $COMMAND command run successfully 🎉"
-    else
+    if [ $? -ne 0 ]; then
         exit $?
     fi
 else


### PR DESCRIPTION
This PR will remove the success message output on all commands, as it can cause confusion when incorrect commands run successfully. For example:

`skm dotnet new` returns "command run successfully" but will not successfully create a project.

This now defers the last message to be the output of the command being run.