### PR TITLE
NEW: Add deploy for native applications

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+if [ -f "${APP_PATH}/$1/skm_deploy_$1.sh" ]; then
+    "${APP_PATH}/$1/skm_deploy_$1.sh" $*
+else
+    "$APP_PATH/help.sh"
+    exit 1
+fi

--- a/deploy/help.sh
+++ b/deploy/help.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+SKM_PATH=`cd "$APP_PATH/.."; pwd`
+
+source "${SKM_PATH}/tools/set_sk_env_vars.sh"
+
+if [ "$1" = "-s" ] ; then
+    echo "    deploy     Package your SplashKit program for deployment to others."
+else
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+
+    echo "OVERVIEW: package your program so it can be deployed elsewhere"
+    echo
+    echo "USAGE: skm deploy [language]"
+    echo
+    echo "Perform necessary steps to create a build of your SplashKit program that can be distributed to others."
+    echo
+    echo "LANGUAGES:"
+    echo
+    echo "You can create projects for the following languages:"
+    echo
+
+    for i in `find "$APP_PATH" -maxdepth 1 -type d | sort`
+    do
+        if [ -f "$i/lang_details.sh" ]; then
+            "$i/lang_details.sh"
+        fi
+    done
+
+    echo
+    echo "Example usage:"
+    echo "    Deploy MyGame executable."
+    echo "    ${bold}skm deploy native MyGame${normal}"
+fi
+

--- a/deploy/native/lang_details.sh
+++ b/deploy/native/lang_details.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "    native     Deploy a standard executable SplashKit project (eg c++/Pascal)"

--- a/deploy/native/skm_deploy_native.sh
+++ b/deploy/native/skm_deploy_native.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+SKM_PATH=`cd "$APP_PATH/../.."; pwd`
+
+source "${SKM_PATH}/tools/set_sk_env_vars.sh"
+
+if [ "$SK_OS" = "macos" ]; then
+    "${APP_PATH}"/skm_deploy_native_mac.sh $1 $2
+else
+    cp -r -n "${APP_PATH}/files/" -T .
+fi

--- a/deploy/native/skm_deploy_native_mac.sh
+++ b/deploy/native/skm_deploy_native_mac.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+SKM_PATH=`cd "$APP_PATH/../.."; pwd`
+
+source "${SKM_PATH}/tools/set_sk_env_vars.sh"
+
+CURRENT_PATH=`pwd`
+GAME_NAME=${CURRENT_PATH##*/}
+
+GAMEAPP_PATH="./deploy/${GAME_NAME}.app"
+if [ -d "${GAMEAPP_PATH}" ]; then
+    rm -rf "${GAMEAPP_PATH}"
+fi
+
+if [ ! -d "./deploy" ]; then
+    mkdir ./deploy
+fi
+
+echo "Creating Mac Application Bundle"
+
+mkdir "${GAMEAPP_PATH}"
+mkdir "${GAMEAPP_PATH}/Contents"
+mkdir "${GAMEAPP_PATH}/Contents/MacOS"
+mkdir "${GAMEAPP_PATH}/Contents/Frameworks"
+
+echo "Copying Resources"
+if [ -d "./Resources" ]; then
+    cp -r -n "./Resources" "${GAMEAPP_PATH}/Contents/"
+fi
+
+echo "Copying executable"
+cp "$2" "${GAMEAPP_PATH}/Contents/MacOS/"
+cp "$SKM_PATH/lib/macos/libSplashKit.dylib" "${GAMEAPP_PATH}/Contents/MacOS/"
+
+echo "Adding meta-data"
+echo "<?xml version='1.0' encoding='UTF-8'?>\
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\
+<plist version=\"1.0\">\
+<dict>\
+        <key>CFBundleDevelopmentRegion</key>\
+        <string>English</string>\
+        <key>CFBundleExecutable</key>\
+        <string>$2</string>\
+        <key>CFBundleIconFile</key>\
+        <string>${ICON}</string>\
+        <key>CFBundleIdentifier</key>\
+        <string>io.splashkit.${GAME_NAME}</string>\
+        <key>CFBundleInfoDictionaryVersion</key>\
+        <string>6.0</string>\
+        <key>CFBundleName</key>\
+        <string>${GAME_NAME}</string>\
+        <key>CFBundlePackageType</key>\
+        <string>APPL</string>\
+        <key>CFBundleSignature</key>\
+        <string>SPLA</string>\
+        <key>CFBundleVersion</key>\
+        <string>1.0</string>\
+        <key>CSResourcesFileMapped</key>\
+        <true/>\
+</dict>\
+</plist>" >> "${GAMEAPP_PATH}/Contents/Info.plist"
+
+echo "APPLSPLA" >> "${GAMEAPP_PATH}/Contents/PkgInfo"


### PR DESCRIPTION
This PR adds the ability to create a deployable package for a SplashKit executable. Currently, this creates a deployable application for Mac.

```c++
skm deploy native a.out
```