### PR TITLE
Add build-essential to debian splashkit deps

### DIFF
--- a/linux/install/install_deps.sh
+++ b/linux/install/install_deps.sh
@@ -4,14 +4,14 @@ export DISTRO_ID="UNKNOWN"
 export DISTRO_VERSION="UNKNOWN"
 
 to_upper () {
-  echo $@ | tr [a-z] [A-Z] 
+  echo $@ | tr [a-z] [A-Z]
 }
 
 detect_distro () {
   if [ -e /etc/os-release ]; then
     source /etc/os-release
     export DISTRO_ID=$(to_upper ${ID})
-  elif (lsb_release); then 
+  elif (lsb_release); then
     export DISTRO_ID=$( to_upper $(lsb_release -is) )
   else
 	if (apt-get 2>&1 | grep -v "command not found"); then
@@ -21,7 +21,7 @@ detect_distro () {
 	  echo "We think you're using a Arch Linux like distro"
 	  export DISTRO_ID="ARCH"
 	elif (dnf 2>&1 | grep -v "command not found"); then
-	  echo "We think you're using a Fedora like distro" 
+	  echo "We think you're using a Fedora like distro"
 	  export DISTRO_ID="FEDORA"
     else
       echo Unable to detect Linux distrobution
@@ -32,23 +32,23 @@ detect_distro () {
 }
 
 install_deps () {
-  case $1 in 
+  case $1 in
 	ARCH )
 	  echo Installing depencies with Arch Linux method
 	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
-	  echo   pacman -S --needed cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod	
-	  sudo pacman -S --needed cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod	
+	  echo   pacman -S --needed cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod
+	  sudo pacman -S --needed cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod
 	  ;;
     DEBIAN | UBUNTU | KALI )
 	  echo Installing depencies with $1 method
 	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
-	  echo   apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev
-	  sudo apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev
+	  echo   apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev build-essential
+	  sudo apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev build-essential
 	  ;;
 	FEDORA )
 	  echo Installing depencies with Fedora method
 	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
-	  echo   dnf install cmake libpng-devel libcurl-devel SDL2-devel SDL2_mixer-devel SDL2_gfx-devel SDL2_image-devel SDL2_net-devel SDL2_ttf-devel libmikmod-devel ncurses-devel bzip2-devel flac-devel libvorbis-devel libwebp-devel freetype-devel 
+	  echo   dnf install cmake libpng-devel libcurl-devel SDL2-devel SDL2_mixer-devel SDL2_gfx-devel SDL2_image-devel SDL2_net-devel SDL2_ttf-devel libmikmod-devel ncurses-devel bzip2-devel flac-devel libvorbis-devel libwebp-devel freetype-devel
 	  sudo dnf install cmake libpng-devel libcurl-devel SDL2-devel SDL2_mixer-devel SDL2_gfx-devel SDL2_image-devel SDL2_net-devel SDL2_ttf-devel libmikmod-devel ncurses-devel bzip2-devel flac-devel libvorbis-devel libwebp-devel freetype-devel
 	  ;;
 	*)


### PR DESCRIPTION
cmake requires the `build-essential` package to be installed on Debian in order to configure splashkit otherwise it throws this error
```
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:6 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```