### PR TITLE
Remove exporting SKM PATH to .bash_profile

### DIFF
--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -33,7 +33,6 @@ fi
 git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 
 # Add SKM app to path without needing sudo
-echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
 echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 
 if [ -f ~/.zshrc ]; then


### PR DESCRIPTION
Bad practice to put in 2 places, .bash_profile is complicated and not standard across systems (Ubuntu uses .profile), so creating a .bash_profile can break things. pls fix