### PR TITLE
Fix zsh shell config issues on Mac OS

### DIFF
--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -33,10 +33,15 @@ fi
 git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 
 # Add SKM app to path without needing sudo
-echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
-echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 
-if [ -f ~/.zshrc ]; then
+# Add to .bashrc if using bash
+if [ ${SHELL} -eq "/bin/bash" ]; then
+    echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
+    echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
+fi
+
+# Add to .zshrc if using zsh
+if [ ${SHELL} -eq "/bin/zsh" ]; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
 fi
 

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -35,13 +35,13 @@ git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 # Add SKM app to path without needing sudo
 
 # Add to .bashrc if using bash
-if [ ${SHELL} -eq "/bin/bash" ]; then
+if [ ${SHELL} = "/bin/bash" ]; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 fi
 
 # Add to .zshrc if using zsh
-if [ ${SHELL} -eq "/bin/zsh" ]; then
+if [ ${SHELL} = "/bin/zsh" ]; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
 fi
 


### PR DESCRIPTION
As of Mac OS X Catalina, the default shell is zsh but `~/.zshrc` isn't present. This PR changes the skm installer to use the `$SHELL` environment variable in order to detect the current shell.