### PR TITLE
ENHANCE: LIBS environment variable

### DIFF
--- a/clang++/clang++.sh
+++ b/clang++/clang++.sh
@@ -16,7 +16,7 @@ elif [ "$SK_OS" = "win64" ]; then
 elif [ "$SK_OS" = "macos" ]; then
     clang++ $CPP_OPTIONS -L"$DYLIB_PATH" -lSplashKit -L"${APP_PATH}/lib/macos" -lSplashKitCpp -I "${APP_PATH}/include" -rpath @loader_path -rpath "$DYLIB_PATH" -rpath /usr/local/lib $*
 elif [ "$SK_OS" = "linux" ]; then
-    clang++ $CPP_OPTIONS -L"$DYLIB_PATH" -L"${APP_PATH}/lib/linux" -I "${APP_PATH}/include" -Wl,-rpath=$ORIGIN -Wl,-rpath="${DYLIB_PATH}" -Wl,-rpath=/usr/local/lib $* -lSplashKitCPP -lSplashKit
+    clang++ $CPP_OPTIONS -L"$DYLIB_PATH" -L"${APP_PATH}/lib/linux" -I "${APP_PATH}/include" -Wl,-rpath=$ORIGIN -Wl,-rpath="${DYLIB_PATH}" -Wl,-rpath=/usr/local/lib $* -lSplashKitCPP -lSplashKit ${LIBS}
 else
     echo "Unable to detect operating system..."
     exit 1

--- a/clang++/help.sh
+++ b/clang++/help.sh
@@ -9,8 +9,11 @@ else
     echo "OVERVIEW: skm clang++ compiler call"
     echo
     echo "USAGE: skm clang++ [options] input"
-    echo 
+    echo
     echo "Runs the clang++ (or g++) compiler with any requested options and input files."
+    echo
+    echo "ENVIRONMENT VARS:"
+    echo "    LIBS: A string which can be used to specify other librarys which depend on SplashKit"
     echo
     echo "Example usage:"
     echo "    Compile a 'program.cpp' file into an executable program called 'HelloWorld'."
@@ -18,8 +21,10 @@ else
     echo
     echo "    Compile all of the cpp files into an executable program called 'MyProgram'."
     echo "    ${bold}skm clang++ *.cpp -o MyProgram${normal}"
-    echo 
+    echo
     echo "    Output options for the clang++ compiler"
     echo "    ${bold}skm clang++ --help${normal}"
+    echo
+    echo "    Using the LIBS envvar to compile with other libraries which depend on SplashKit."
+    echo "    ${bold}LIBS='-lfirestorm' skm clang++ program.cpp${normal}"
 fi
-

--- a/g++/g++.sh
+++ b/g++/g++.sh
@@ -16,7 +16,7 @@ elif [ "$SK_OS" = "win64" ]; then
 elif [ "$SK_OS" = "macos" ]; then
     g++ $CPP_OPTIONS -L"$DYLIB_PATH" -lSplashKit -L"${APP_PATH}/lib/macos" -lSplashKitCpp -I "${APP_PATH}/include" -rpath @loader_path -rpath "$DYLIB_PATH" -rpath /usr/local/lib $*
 elif [ "$SK_OS" = "linux" ]; then
-    g++ $CPP_OPTIONS -L"$DYLIB_PATH" -L"${APP_PATH}/lib/linux" -I "${APP_PATH}/include" -Wl,-rpath=$ORIGIN -Wl,-rpath="${DYLIB_PATH}" -Wl,-rpath=/usr/local/lib $* -lSplashKitCPP -lSplashKit
+    g++ $CPP_OPTIONS -L"$DYLIB_PATH" -L"${APP_PATH}/lib/linux" -I "${APP_PATH}/include" -Wl,-rpath=$ORIGIN -Wl,-rpath="${DYLIB_PATH}" -Wl,-rpath=/usr/local/lib $* -lSplashKitCPP -lSplashKit ${LIBS}
 else
     echo "Unable to detect operating system..."
     exit 1

--- a/g++/help.sh
+++ b/g++/help.sh
@@ -9,7 +9,10 @@ else
     echo "OVERVIEW: skm g++ compiler call"
     echo
     echo "USAGE: skm g++ [options] input"
-    echo 
+    echo
+    echo "ENVIRONMENT VARS:"
+    echo "    LIBS: A string which can be used to specify other librarys which depend on SplashKit"
+    echo
     echo "Runs the g++ (or g++) compiler with any requested options and input files."
     echo
     echo "Example usage:"
@@ -18,8 +21,10 @@ else
     echo
     echo "    Compile a all of the cpp files into an executable program called 'MyProgram'."
     echo "    ${bold}skm g++ *.cpp -o MyProgram${normal}"
-    echo 
+    echo
     echo "    Output options for the g++ compiler"
     echo "    ${bold}skm g++ --help${normal}"
+    echo
+    echo "    Using the LIBS envvar to compile with other libraries which depend on SplashKit."
+    echo "    ${bold}LIBS='-lfirestorm' skm g++ program.cpp${normal}"
 fi
-


### PR DESCRIPTION
Add the option to specify the `LIBS` environment variable when using g++ or clang++ to specify extra libraries which depend on splashkit. For an example

```
$ LIBS="-lfirestorm" skm g++ program.cpp
```

Currently this has only been implemented for Linux but if could also be implemented for Mac and Windows platforms then that would be ideal.