### PR TITLE
FIX: Fix compiler error on clang

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,6 +46,12 @@ include_directories("${SKM_ROOT}/source/include")
 find_package(PNG REQUIRED)
 find_package(CURL REQUIRED)
 include_directories(${PNG_INCLUDE_DIR})
+
+# Fix clang not compiling because being_code.h doesn't exit
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include_directories("/usr/include/SDL2")
+endif()
+
 SET(LINUX "true")
 set(LIB_FLAGS "-lSDL2 \
                -lSDL2_mixer \


### PR DESCRIPTION
When compiling splashkit using clang, clang errors with 
```
fatal error: 'begin_code.h' file not found 
```

This PR fixes that.

PS: Yeah I know it's a bit of a hack, hence the if statement checking to see if the current compiler is clang

PPS: On second thoughts this should probably be fixed upstream and not in skm directly. If that's the case then I can also create a PR there. It would be nice to fix this issue relatively quickly though [so my CI doesn't keep failing](https://travis-ci.com/github/hugglesfox/firestorm/builds/186866464).