### PR TITLE
Bump C++ version to C++17

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,7 +74,7 @@ set(LIB_FLAGS "-lSDL2 \
                -ldl")
 
 # FLAGS
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)


### PR DESCRIPTION
Currently on Linux skm tries to compile splashkit using C++14 which causes a not declared error due to Splashkit trying to make use of the [recursive_directory_iterator](https://en.cppreference.com/w/cpp/filesystem/recursive_directory_iterator) function which was added in C++17.

![Screenshot from 2021-03-03 15-48-02](https://user-images.githubusercontent.com/25257393/109755047-242f4a80-7bdd-11eb-8d86-05006efcedd5.png)