### PR TITLE
CONFIG: Disable ImplicitUsings property

### DIFF
--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -18,8 +18,10 @@ fi
 
 if [ $SK_OS = "macos" ]; then
     sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
+    sed -i '' "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
 else
     sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
+    sed -i "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
 fi
 
 dotnet restore


### PR DESCRIPTION
CONFIG: Fix project file to disable ImplicitUsings property
Due to .NET5.0 not using this feature in Visual Studio