### PR TITLE
fix:fix the install script for zsh user

### DIFF
--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -35,13 +35,13 @@ git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 # Add SKM app to path without needing sudo
 
 # Add to .bashrc if using bash
-if [ ${SHELL} = "/bin/bash" ]; then
+if [[ ${SHELL} = "/bin/bash" ]] || [[ ${SHELL} = "/usr/bin/bash" ]] ; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 fi
 
 # Add to .zshrc if using zsh
-if [ ${SHELL} = "/bin/zsh" ]; then
+if [[ ${SHELL} = "/bin/zsh" ]] || [[ ${SHELL} = "/usr/bin/zsh" ]]; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
 fi
 

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -35,7 +35,7 @@ git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 # Add SKM app to path without needing sudo
 
 # Add to .bashrc if using bash
-if [[ ${SHELL} = "/bin/bash" ]] || [[ ${SHELL} = "/usr/bin/bash" ]] ; then
+if [[ ${SHELL} = "/bin/bash" ]] || [ ${SHELL} = "/usr/bin/bash" -a `uname` = Linux ] ; then
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
     echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 fi


### PR DESCRIPTION
# Description

When I tried to install the skm on my linux, I found that the PATH is failed to add in .zshrc. So I checked my ` SHELL ` variable. It shows:
![image](https://user-images.githubusercontent.com/33137074/159846765-bd18c8ad-68d4-4452-a0bd-9c631a2f402a.png)

So I added a or condition 
```bash
# for bash
if [[ ${SHELL} = "/bin/bash" ]] || [[ ${SHELL} = "/usr/bin/bash" ]]

# for zsh
if [[ ${SHELL} = "/bin/zsh" ]] || [[ ${SHELL} = "/usr/bin/zsh" ]];
```


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
I have removed the skm and reinstall to see if the script work.

![image](https://user-images.githubusercontent.com/33137074/159847257-8b3b91ce-a7aa-49d6-a954-edd8354abf79.png)
![image](https://user-images.githubusercontent.com/33137074/159847285-ec89b8bc-c766-45b7-a00d-3b0cd204ee01.png)

The PATH add to the ` .zshrc `

