### PR TITLE
CONFIG: Fix csproj for dotnet on macos using VS.

### DIFF
--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -17,11 +17,15 @@ else
 fi
 
 if [ $SK_OS = "macos" ]; then
-    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
-    sed -i '' "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
+    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
+    sed -i '' "s|</Project>|  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
+    <StartAction>Project</StartAction>\n\
+    <ExternalConsole>true</ExternalConsole>\n\
+    <EnvironmentVariables>\n\
+      <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\
+    </EnvironmentVariables>\n  </PropertyGroup>\n\n</Project>|g" "$PRJ_NAME"
 else
-    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
-    sed -i "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
+    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
 fi
 
 dotnet restore


### PR DESCRIPTION
SplashKit project now works "out of the box" for macos users using Visual Studio IDE.
Updated config to use .NET 6.0 (This is for windows also, as splashkit seems to be stable on .NET 6.0 for windows)
Removed disabled implicit usings property since feature is compatible with .NET 6.0

**WARNING:** This patch assumes a recompiled/updated libSplashKit.dylib to a universal binary that supports both x86 and ARM64 architectures on macos. **Do not** merge before updating the binary in the repository.