### PR TITLE
CONFIG: Update C# (dotnet) project configuration

### DIFF
--- a/dotnet/files/Program.cs
+++ b/dotnet/files/Program.cs
@@ -1,10 +1,13 @@
 using System;
 using SplashKitSDK;
 
-public class Program
+namespace SkmProject
 {
-    public static void Main()
+    public class Program
     {
+        public static void Main()
+        {
 
+        }
     }
 }

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -30,4 +30,10 @@ else
     sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
 fi
 
+if [ $SK_OS = "macos" ]; then
+    sed -i '' "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+else
+    sed -i "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+fi
+
 dotnet restore

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -18,6 +18,14 @@ fi
 
 if [ $SK_OS = "macos" ]; then
     sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
+    if ! grep -q RunConfiguration "$PRJ_NAME"; then
+        sed -i '' "s|</Project>|  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
+    <StartAction>Project</StartAction>\n\
+    <ExternalConsole>true</ExternalConsole>\n\
+    <EnvironmentVariables>\n\
+    <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\
+    </EnvironmentVariables>\n  </PropertyGroup>\n\n</Project>|g" "$PRJ_NAME"
+    fi
 else
     sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
 fi

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -17,11 +17,9 @@ else
 fi
 
 if [ $SK_OS = "macos" ]; then
-    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
-    sed -i '' "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
+    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
 else
-    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>netcoreapp5.0</TargetFramework>|g" "$PRJ_NAME"
-    sed -i "s|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|g" "$PRJ_NAME"
+    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
 fi
 
 dotnet restore

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -5,6 +5,13 @@ APP_PATH=`cd "$APP_PATH"; pwd`
 
 PRJ_NAME="${PWD##*/}.csproj"
 SKM_PATH=`cd "$APP_PATH/../.."; pwd`
+PROGRAM_CS_NAME='Program.cs'
+MAC_RUN_CONFIG="  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
+    <StartAction>Project</StartAction>\n\
+    <ExternalConsole>true</ExternalConsole>\n\
+    <EnvironmentVariables>\n\
+    <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\
+    </EnvironmentVariables>\n  </PropertyGroup>\n"
 
 source "${SKM_PATH}/tools/set_sk_env_vars.sh"
 
@@ -19,12 +26,7 @@ fi
 if [ $SK_OS = "macos" ]; then
     sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
     if ! grep -q RunConfiguration "$PRJ_NAME"; then
-        sed -i '' "s|</Project>|  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
-    <StartAction>Project</StartAction>\n\
-    <ExternalConsole>true</ExternalConsole>\n\
-    <EnvironmentVariables>\n\
-    <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\
-    </EnvironmentVariables>\n  </PropertyGroup>\n\n</Project>|g" "$PRJ_NAME"
+        sed -i '' "s|</Project>|$MAC_RUN_CONFIG\n</Project>|g" "$PRJ_NAME"
     fi
 else
     sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"


### PR DESCRIPTION
This PR adds the following:

- The 'namespace' is now included in the Program.cs file, and will then be updated from 'SkmProject' to use the name of the folder that the project was created inside as the updated namespace. 
- Update to use .NET 6 (.net6.0 instead of netcoreapp5.0)
- Added Run Configuration to the project file for macos. This allows a SplashKit project to be run directly from Visual Studio without needing to use the terminal separately.
