### PR TITLE
ADD/CONFIG: Update directory name for project file and namespace

### DIFF
--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -3,7 +3,13 @@
 APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
 APP_PATH=`cd "$APP_PATH"; pwd`
 
-PRJ_NAME="${PWD##*/}.csproj"
+DIR_NAME="${PWD##*/}"
+CORRECTED_DIR_NAME="${DIR_NAME//[ .]/_}"
+if [[ "${CORRECTED_DIR_NAME::1}" =~ [0-9] ]]; then
+    CORRECTED_DIR_NAME="_$CORRECTED_DIR_NAME"
+fi
+INIT_PRJ_NAME=`echo *.csproj`
+PRJ_NAME="$CORRECTED_DIR_NAME.csproj"
 SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 PROGRAM_CS_NAME='Program.cs'
 MAC_RUN_CONFIG="  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
@@ -23,6 +29,10 @@ else
     sed -i "s|\"LD_LIBRARY_PATH\":.*\".*\"|\"LD_LIBRARY_PATH\": \"$DYLIB_PATH\"|g" ./.vscode/launch.json
 fi
 
+if [ "$INIT_PRJ_NAME" != "$PRJ_NAME" ]; then
+    mv "$INIT_PRJ_NAME" "$PRJ_NAME"
+fi
+
 if [ $SK_OS = "macos" ]; then
     sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
     if ! grep -q RunConfiguration "$PRJ_NAME"; then
@@ -33,9 +43,9 @@ else
 fi
 
 if [ $SK_OS = "macos" ]; then
-    sed -i '' "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+    sed -i '' "s|namespace .*|namespace $CORRECTED_DIR_NAME|g" "$PROGRAM_CS_NAME"
 else
-    sed -i "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+    sed -i "s|namespace .*|namespace $CORRECTED_DIR_NAME|g" "$PROGRAM_CS_NAME"
 fi
 
 dotnet restore


### PR DESCRIPTION
The current directory name is updated to conform with project naming conventions (fixing most common naming errors):
- If the name of the folder the project is created in starts with a number, then an underscore (_) will be added to the start.
- Any spaces or periods in the folder name will be replaced with underscores (_).

Extra notes:
- Using `skm dotnet restore` will update both the .csproj filename and namespace in the Program.cs file to use the 'corrected' current directory name.
- Tested on both macos and Windows successfully.
- This does not change the name of the folder that the project is created in, just the .csproj filename and the namespace in the Program.cs file.