### PR TITLE
CONFIG: Update C# project naming and 'run configuration' for macOS

### DIFF
--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -15,7 +15,7 @@ SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 PROGRAM_CS_NAME='Program.cs'
 MAC_RUN_CONFIG="  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
     <StartAction>Project</StartAction>\n\
-    <StartWorkingDirectory>.</StartWorkingDirectory>\
+    <StartWorkingDirectory>.</StartWorkingDirectory>\n\
     <ExternalConsole>true</ExternalConsole>\n\
     <EnvironmentVariables>\n\
     <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -3,7 +3,14 @@
 APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
 APP_PATH=`cd "$APP_PATH"; pwd`
 
-PRJ_NAME="${PWD##*/}.csproj"
+DIR_NAME="${PWD##*/}"
+CORRECTED_DIR_NAME="${DIR_NAME//[^A-Za-z0-9]/_}"
+if [[ "${CORRECTED_DIR_NAME::1}" =~ [0-9] ]]; then
+    CORRECTED_DIR_NAME="_$CORRECTED_DIR_NAME"
+fi
+INIT_PRJ_NAME=`echo *.csproj`
+PRJ_NAME="$CORRECTED_DIR_NAME.csproj"
+
 SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 PROGRAM_CS_NAME='Program.cs'
 MAC_RUN_CONFIG="  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
@@ -24,6 +31,10 @@ else
     sed -i "s|\"LD_LIBRARY_PATH\":.*\".*\"|\"LD_LIBRARY_PATH\": \"$DYLIB_PATH\"|g" ./.vscode/launch.json
 fi
 
+if [ "$INIT_PRJ_NAME" != "$PRJ_NAME" ]; then
+    mv -- "$INIT_PRJ_NAME" "$PRJ_NAME"
+fi
+
 if [ $SK_OS = "macos" ]; then
     sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
     if ! grep -q RunConfiguration "$PRJ_NAME"; then
@@ -34,9 +45,9 @@ else
 fi
 
 if [ $SK_OS = "macos" ]; then
-    sed -i '' "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+    sed -i '' "s|namespace .*|namespace $CORRECTED_DIR_NAME|g" "$PROGRAM_CS_NAME"
 else
-    sed -i "s|namespace SkmProject|namespace ${PWD##*/}|g" "$PROGRAM_CS_NAME"
+    sed -i "s|namespace .*|namespace $CORRECTED_DIR_NAME|g" "$PROGRAM_CS_NAME"
 fi
 
 dotnet restore

--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -8,6 +8,7 @@ SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 PROGRAM_CS_NAME='Program.cs'
 MAC_RUN_CONFIG="  <PropertyGroup Condition=\" '\$(RunConfiguration)' == 'Default' \">\n\
     <StartAction>Project</StartAction>\n\
+    <StartWorkingDirectory>.</StartWorkingDirectory>\
     <ExternalConsole>true</ExternalConsole>\n\
     <EnvironmentVariables>\n\
     <Variable name=\"DYLD_LIBRARY_PATH\" value=\"$DYLIB_PATH\" />\n\


### PR DESCRIPTION
**1. FIX:** C# Projects using Visual Studio on macos with the "Resources" folder can now be run _directly_ from Visual Studio:
- Previously, any loaded resources were not able to be located in the Resources folder when running directly from Visual studio, which would result in warnings.
- Now, SplashKit projects that include loading resources from the "Resources" folder are able to run correctly with just the Run button.

**2. FEAT:** When creating a new SplashKit C# project, the current directory name is updated to conform with C# project naming conventions (fixing most common naming errors):
- If the name of the folder the project is created in starts with a number, then an underscore (_) will be added to the start.
- Any special characters (characters other than A-Z, a-z or 0-9) in the folder name will be replaced with underscores (_).
- Using both/either `skm dotnet new` or `skm dotnet restore` will update both the .csproj filename and namespace in the Program.cs file to use the 'corrected' current directory name. This does not affect any new code added to the Program.cs file.
- _This does not change the name of the folder that the project is created in, just the .csproj filename and the namespace in the Program.cs file._
- Updates have been tested on both macos and Windows successfully.