### PR TITLE
FIX: Include <cstdint> library to networking header

### DIFF
--- a/clang++/include/networking.h
+++ b/clang++/include/networking.h
@@ -6,6 +6,7 @@
 #ifndef __networking_h
 #define __networking_h
 
+#include <cstdint>
 #include <string>
 #include <vector>
 using std::string;

--- a/g++/include/networking.h
+++ b/g++/include/networking.h
@@ -6,6 +6,7 @@
 #ifndef __networking_h
 #define __networking_h
 
+#include <cstdint>
 #include <string>
 #include <vector>
 using std::string;


### PR DESCRIPTION
Due to recent updates for GCC 13, the networking.h files need to include the <cstdint> library explicitly now.

By including this library, the issue seems to be resolved, and the splashkit program.cpp file now compiles correctly. 
Tested for both clang++ and g++.