### PR TITLE
Update TargetFrameWork to net7.0

### DIFF
--- a/fix/dotnet/skm_fix_dotnet.sh
+++ b/fix/dotnet/skm_fix_dotnet.sh
@@ -36,12 +36,12 @@ if [ "$INIT_PRJ_NAME" != "$PRJ_NAME" ]; then
 fi
 
 if [ $SK_OS = "macos" ]; then
-    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
+    sed -i '' "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net7.0</TargetFramework>|g" "$PRJ_NAME"
     if ! grep -q RunConfiguration "$PRJ_NAME"; then
         sed -i '' "s|</Project>|$MAC_RUN_CONFIG\n</Project>|g" "$PRJ_NAME"
     fi
 else
-    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net6.0</TargetFramework>|g" "$PRJ_NAME"
+    sed -i "s|<TargetFramework>.*</TargetFramework>|<TargetFramework>net7.0</TargetFramework>|g" "$PRJ_NAME"
 fi
 
 if [ $SK_OS = "macos" ]; then


### PR DESCRIPTION
Due to net7.0 being the most commonly installed framework with Visual Studio.

Confirmed that net7.0 has the same compatibility with SplashKit as net6.0.