### PR TITLE
Update skm_global_install.sh fix path with spaces

### DIFF
--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -64,14 +64,14 @@ fi
 
 # If $WIN_OUT_DIR is set, we are on Windows and need to copy the dll to the System32 or System64 directory
 if [ ! -z "$WIN_OUT_DIR" ]; then
-    $PRIVILEGED cp $LIB_FILE $WIN_OUT_DIR
+    $PRIVILEGED cp "$LIB_FILE" "$WIN_OUT_DIR"
     if [ ! $? -eq 0 ]; then
         echo "Failed to copy SplashKit library to $WIN_OUT_DIR"
         exit 1
     fi
 fi
 
-$PRIVILEGED cp $CPP_LIB_FILE /usr/local/lib
+$PRIVILEGED cp "$CPP_LIB_FILE" /usr/local/lib
 if [ ! $? -eq 0 ]; then
     echo "Failed to copy SplashKit C++ library to /usr/local/lib"
     exit 1
@@ -109,19 +109,19 @@ fi
 echo "Testing install"
 
 if [ "$SK_OS" = "macos" ]; then
-    clang++ ${APP_PATH}/test.cpp -l SplashKitCPP -l SplashKit -rpath /usr/local/lib -o ${APP_PATH}/test
+    clang++ "${APP_PATH}/test.cpp" -l SplashKitCPP -l SplashKit -rpath /usr/local/lib -o "${APP_PATH}/test"
     if [ ! $? -eq 0 ]; then
         echo "Failed to compile test program"
         exit 1
     fi
 elif [ "$SK_OS" = "linux" ]; then
-    g++ ${APP_PATH}/test.cpp -l SplashKitCPP -l SplashKit -Wl,-rpath=/usr/local/lib -o ${APP_PATH}/test
+    g++ "${APP_PATH}/test.cpp" -l SplashKitCPP -l SplashKit -Wl,-rpath=/usr/local/lib -o "${APP_PATH}/test"
     if [ ! $? -eq 0 ]; then
         echo "Failed to compile test program"
         exit 1
     fi
 elif [ "$IS_WINDOWS" = true ]; then
-    g++ ${APP_PATH}/test.cpp -L /usr/local/lib -lSplashKit -I /usr/local/include/ /usr/local/lib/libSplashKitCPP.a -o ${APP_PATH}/test
+    g++ "${APP_PATH}/test.cpp" -L /usr/local/lib -lSplashKit -I /usr/local/include/ /usr/local/lib/libSplashKitCPP.a -o "${APP_PATH}/test"
 
     if [ ! $? -eq 0 ]; then
         echo "Failed to compile test program"
@@ -129,12 +129,12 @@ elif [ "$IS_WINDOWS" = true ]; then
     fi
 fi
 
-${APP_PATH}/test
+"${APP_PATH}/test"
 if [ ! $? -eq 0 ]; then
     echo "Failed to run test program"
     exit 1
 fi
 
-rm ${APP_PATH}/test
+rm "${APP_PATH}/test"
 
 echo "Done"


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request addresses an issue related to path handling on Windows systems where user usernames contain spaces. The problem arises during installation/linking processes, causing failures due to the absence of proper quoting.

#### Changes Made
To mitigate this issue, this pull request introduces the addition of quotes around all installation/linking paths in the relevant code sections. By encapsulating paths with spaces in quotes, we ensure that the global installation command works seamlessly for Windows users with usernames containing spaces.

#### Motivation
The motivation behind this fix is to enhance the user experience for Windows users and prevent installation/linking failures that occur when paths with spaces are not handled appropriately. By implementing this change, we aim to make the installation process more robust and user-friendly, accommodating a wider range of system configurations.

#### Related Issues
Closes #[Issue Number]: Describe any related issues that are being resolved or addressed by this pull request.

#### Checklist
- [x] Code follows the project's coding conventions.
- [x] The pull request title and description clearly convey the purpose and impact of the changes.

