### PR TITLE
Suppress splashkit not found error message during install

### DIFF
--- a/linux/install/install.sh
+++ b/linux/install/install.sh
@@ -5,6 +5,8 @@ APP_PATH=`cd "$APP_PATH"; pwd`
 
 SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 
+# Suppress the splashkit not found error (we're installing splashkit)
+mkdir -p "$SKM_PATH/lib/linux"
 source "${SKM_PATH}/tools/set_sk_env_vars.sh"
 
 if [ "$SK_OS" = "linux" ] || ( echo "${*}" | grep '\-\-no-os-detect' ); then


### PR DESCRIPTION
When `set_sk_env_vars.sh` is sourced from `linux/install/install.sh` it prints the error message 
> Unable to locate SplashKit library - please run skm linux install

due to the `lib/linux` not being created yet (as you're still yet to install splashkit). This PR creates the directory in the install script before `set_sk_env_vars.sh` is sourced which suppresses the error message.