### PR TITLE
build(gpio): add link to pigpiod and define rpi

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,4 @@
-#
 # CMake file for generating the splashkit core library
-#
 
 cmake_minimum_required(VERSION 3.5)
 project(SplashKit)
@@ -11,9 +9,52 @@ if (WIN32 OR MSYS OR MINGW)
     return ()
 elseif (APPLE)
     set(PATH_SUFFIX "macos")
-else  ( )
+else()
     set(PATH_SUFFIX "linux")
-    SET(LINUX "true")
+
+    # Detect if the platform is Raspberry Pi
+    set(RASPBERRY_PI FALSE)
+
+    # Method 1: Check for Raspberry Pi specific file
+    if(EXISTS "/proc/device-tree/model")
+        file(READ "/proc/device-tree/model" DEVICE_MODEL)
+        if(DEVICE_MODEL MATCHES "Raspberry Pi")
+            set(RASPBERRY_PI TRUE)
+        endif()
+    endif()
+
+    # Method 2: Check for ARM architecture and Broadcom chip
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)")
+        if(EXISTS "/proc/cpuinfo")
+            file(READ "/proc/cpuinfo" CPU_INFO)
+            if(CPU_INFO MATCHES "BCM[0-9]+")
+                set(RASPBERRY_PI TRUE)
+            endif()
+        endif()
+    endif()
+
+    if(RASPBERRY_PI)
+        message("-- Raspberry Pi Detected")
+
+        # RASPBERRY PI SETUP
+        # Locate Pigpio library
+        find_path(BCM_HOST_INCLUDE_DIR NAMES bcm_host.h PATHS "/opt/vc/include")
+        find_path(PIGPIOD_INCLUDE_DIR NAMES pigpiod_if2.h PATHS "/usr/include")
+        find_library(PIGPIOD_IF2_LIB NAMES pigpiod_if2 HINTS "/usr/lib")
+        find_library(PIGPIO_LIB NAMES pigpio HINTS "/usr/lib")
+
+        # Handle Pigpio library finding
+        include(FindPackageHandleStandardArgs)
+        find_package_handle_standard_args(PIGPIO DEFAULT_MSG PIGPIOD_INCLUDE_DIR PIGPIOD_IF2_LIB PIGPIO_LIB)
+
+        if(PIGPIO_FOUND)
+            message("-- Pigpio libraries found")
+            include_directories(${PIGPIOD_INCLUDE_DIR})
+            add_definitions(-DRASPBERRY_PI)
+        else()
+            message(WARNING "-- Pigpio libraries NOT found. Some features may be unavailable.")
+        endif()
+    endif()
 endif()
 
 # SK Directories relative to cmake project
@@ -43,29 +84,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)
 
-# RASPBERRY PI SETUP #
-if(LINUX)
-    find_path(BCM_HOST_INCLUDE_DIR NAMES ncm_host.h PATHS "opt/vc/include")
-
-    if(BCM_HOST_INCLUDE_DIR)
-        message("-- Raspberry Pi Detected")
-
-        find_path(PIGPIOD_INCLUDE_DIR NAMES pigpiod_if2.h HINTS /usr/include)
-        find_library(PIGPIOD_IF2_LIB NAMES libpigpiod_if2.so HINTS /usr/lib)
-
-        include(FindPackageHandleStandardArgs)
-        find_package_handle_standard_args(PIGPIO DEFAULT_MSG PIGPIOD_INCLUDE_DIR PIGPIOD_IF2_LIB)
-
-        if(PIGPIO_FOUND)
-            message("-- Pigpio library found")
-            include_directories(${PIGPIOD_INCLUDE_DIR})
-            add_definitions(-DRASPBERRY_PI)
-        else()
-            message("-- Pigpio library NOT found")
-        endif()
-    endif()
-endif()
-
 #### END SETUP ####
 
 # SOURCE FILES
@@ -85,15 +103,17 @@ file(GLOB SPLASHKITCPP_SOURCE_FILES
 )
 
 #### SplashKit SHARED LIBRARY ####
-add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${OS_SOURCE_FILES} ${INCLUDE_FILES} "${SPLASHKITCPP_SOURCE_FILES}")
+add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${SPLASHKITCPP_SOURCE_FILES})
 
-target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
-if (APPLE)
-    target_link_libraries(SplashKit "-framework CoreFoundation")
+# Link libraries based on platform
+if (RASPBERRY_PI AND PIGPIO_FOUND)
+    target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS} ${PIGPIOD_IF2_LIB})
+else()
+    target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
 endif()
 
-if(PIGPIO_FOUND)
-    target_link_libraries(SplashKit ${PIGPIOD_IF2_LIB})
+if (APPLE)
+    target_link_libraries(SplashKit "-framework CoreFoundation")
 endif()
 
 install(TARGETS SplashKit DESTINATION ${SK_DEPLOY_ROOT})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -38,7 +38,6 @@ else()
 
         # RASPBERRY PI SETUP
         # Locate Pigpio library
-        find_path(BCM_HOST_INCLUDE_DIR NAMES bcm_host.h PATHS "/opt/vc/include")
         find_path(PIGPIOD_INCLUDE_DIR NAMES pigpiod_if2.h PATHS "/usr/include")
         find_library(PIGPIOD_IF2_LIB NAMES pigpiod_if2 HINTS "/usr/lib")
         find_library(PIGPIO_LIB NAMES pigpio HINTS "/usr/lib")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -43,6 +43,29 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)
 
+# RASPBERRY PI SETUP #
+if(LINUX)
+    find_path(BCM_HOST_INCLUDE_DIR NAMES ncm_host.h PATHS "opt/vc/include")
+
+    if(BCM_HOST_INCLUDE_DIR)
+        message("-- Raspberry Pi Detected")
+
+        find_path(PIGPIOD_INCLUDE_DIR NAMES pigpiod_if2.h HINTS /usr/include)
+        find_library(PIGPIOD_IF2_LIB NAMES libpigpiod_if2.so HINTS /usr/lib)
+
+        include(FindPackageHandleStandardArgs)
+        find_package_handle_standard_args(PIGPIO DEFAULT_MSG PIGPIOD_INCLUDE_DIR PIGPIOD_IF2_LIB)
+
+        if(PIGPIO_FOUND)
+            message("-- Pigpio library found")
+            include_directories(${PIGPIOD_INCLUDE_DIR})
+            add_definitions(-DRASPBERRY_PI)
+        else()
+            message("-- Pigpio library NOT found")
+        endif()
+    endif()
+endif()
+
 #### END SETUP ####
 
 # SOURCE FILES
@@ -67,6 +90,10 @@ add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${OS_SOURCE_FILES
 target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
 if (APPLE)
     target_link_libraries(SplashKit "-framework CoreFoundation")
+endif()
+
+if(PIGPIO_FOUND)
+    target_link_libraries(SplashKit ${PIGPIOD_IF2_LIB})
 endif()
 
 install(TARGETS SplashKit DESTINATION ${SK_DEPLOY_ROOT})


### PR DESCRIPTION
## Description
- Merged in [PR62](https://github.com/splashkit/skm/pull/62 ) from @XQuestCode 
- Removed reference to `/opt/vc/include`

The description for this merged PR is included as a quote below.

These changes have been tested on a Raspberry Pi 4B with a fresh install of Raspberry Pi OS, flashed on 12/09/2024. The test was a duplicate of the one in `sktest`. The test itself behaved as expected.

![image](https://github.com/user-attachments/assets/746e48db-169f-4f10-8d5f-cc7b1a6787e1)

------
> ## Description:
> This pull request enhances the CMakeLists.txt file to detect Raspberry Pi systems and integrate Pigpio library support. The changes include:
> 
> 1. Robust Raspberry Pi detection using two methods:
>    a. Examining `/proc/device-tree/model` for "Raspberry Pi" string
>    b. Checking `/proc/cpuinfo` for ARM architecture and Broadcom chip (BCM)
> 2. Pigpio library detection and integration:
>    
>    * Searches for `pigpiod_if2.h` header and `pigpiod_if2` library
>    * Uses FindPackageHandleStandardArgs for standardized library finding
> 3. Conditional compilation and linking for Raspberry Pi systems:
>    
>    * Adds `-DRASPBERRY_PI` definition when Pigpio is found
>    * Conditionally links Pigpio library to the SplashKit target
> 4. Removed BCM host library detection:
>    
>    * The `/opt/vc/` directory has been deprecated in recent Raspberry Pi OS updates
>    * This ensures compatibility with current Raspberry Pi systems while maintaining Pigpio functionality
> 
> These modifications allow SplashKit to leverage Raspberry Pi-specific features when compiled on such systems, while maintaining compatibility with other Linux distributions. The changes follow CMake best practices for library detection and linking.
> 
> **Note: This update requires Pigpio to be installed on the Raspberry Pi system. Users may need to install it manually if not already present.**
> 
> ## Tested:
> * Raspberry Pi 4 Model B running Raspberry Pi OS (64-bit)
> * Raspberry Pi 3 Model B+ running Raspberry Pi OS (64-bit)
> * Ubuntu 20.04 LTS (to ensure non-Raspberry Pi systems are unaffected)
> * macOS (to verify Apple systems remain unchanged)
> 
> All tests passed successfully, with the CMake configuration detecting Raspberry Pi systems correctly and linking Pigpio when available.
> 
> ## References:
> * https://stackoverflow.com/questions/69759904/unsure-what-to-do-with-the-cmake-file-from-pigpio
> * https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html
> * https://forums.raspberrypi.com/viewtopic.php?t=346890
> * [pi0 arm core voltage isnt being set right with freq scaling raspberrypi/firmware#1525](https://github.com/raspberrypi/firmware/issues/1525)
> * https://cmake.org/cmake/help/latest/command/target_link_libraries.html
> * http://abyz.me.uk/rpi/pigpio/download.html
------
## Original Description

Duplicated PR from: https://github.com/thoth-tech/skm/pull/12

Changed CMakeLists.txt to find pigpio library using `find_path()` and `find_library()` and link it to SplashKit during compilation. We detect if we're on a Raspberry Pi through the bcm_hosts.h file and then we try to find pigpio. If it is found then we will assume we're on an Raspberry Pi and add this definition. This changes are required to access GPIO functionality in SplashKit.


## Type of change
Please delete options that are not relevant.

- [x]  Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

SplashKit uninstalled through skm and then installed with new CMakeLists.txt file, then the GPIO tests in `sktest` was run and this behaved as expected. Next, I successfully created a simple LED blinking program using the GPIO functions in SplashKit.

## Checklist
- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have commented my code in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have requested a review from @XQuestCode on the Pull Request