### PR TITLE
Update Linux install

### DIFF
--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -89,7 +89,7 @@ fi
 
 if [ "$SK_OS" = "linux" ]; then
     echo "Updating library config cache"
-    $PRIVILEGED ldconfig
+    $PRIVILEGED ldconfig /usr/local/lib
 elif [ "$SK_OS" = "macos" ]; then
     echo "Setting library location"
     sudo install_name_tool -id /usr/local/lib/libSplashKit.dylib /usr/local/lib/libSplashKit.dylib

--- a/linux/install/install_deps.sh
+++ b/linux/install/install_deps.sh
@@ -33,7 +33,7 @@ detect_distro () {
 
 install_deps () {
   case $1 in
-	ARCH )
+	ARCH | MANJARO )
 	  echo Installing depencies with Arch Linux method
 	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
 	  echo   pacman -S --needed base-devel cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod clang

--- a/linux/install/install_deps.sh
+++ b/linux/install/install_deps.sh
@@ -41,8 +41,10 @@ install_deps () {
 	  ;;
     DEBIAN | UBUNTU | KALI | RASPBIAN | LINUXMINT )
 	  echo Installing depencies with $1 method
-	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
+	  echo You are about to be prompt for your sudo password to install the dependencies using the following commands:
+	  echo   apt-get update
 	  echo   apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev build-essential clang
+	  sudo apt-get update
 	  sudo apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev build-essential clang
 	  ;;
 	FEDORA )


### PR DESCRIPTION
# Description

This pull request updates the linux installation to fix the global install in Manjaro Linux, and some minor issues with installing dependencies.

## Changes

1. `/usr/local/lib` added to ldconfig line to fix issue with this folder not being automatically searched in some linux distros.
2. Added MANJARO to Arch distros due to its increase in popularity.
3. Added `sudo apt-get` line for installing dependencies in Debian-based distros. This is due to SplashKit's installation guides having been updated to use the more end-user friendly `sudo apt update` instead, which means that `sudo apt-get update` is then missed.
  The line below `sudo apt-get update` could be updated to use `apt` instead of `apt-get` if preferred.

## How Has This Been Tested?

Using `skm linux install` and `skm global install` in both Ubuntu and Manjaro VMs.