### PR TITLE
Fix Python global install

### DIFF
--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -45,19 +45,24 @@ elif [ "$SK_OS" = "linux" ]; then
     fi
 elif [ "$SK_OS" = "win64" ]; then
     # WIN_OUT_DIR="${WINDIR}/System32"
-    if [ "$MSYSTEM" = "MINGW64" ]; then
         LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
         LIB_DEST="/mingw64/lib"
         INC_DEST="/mingw64/include"
-    elif [ "$MSYSTEM" = "CLANG64" ]; then
-        LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
-        LIB_DEST="/clang64/lib"
-        INC_DEST="/clang64/include"
+
+    # Section below commented out for further testing
+    # if [ "$MSYSTEM" = "MINGW64" ]; then
+    #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+    #     LIB_DEST="/mingw64/lib"
+    #     INC_DEST="/mingw64/include"
+    # elif [ "$MSYSTEM" = "CLANG64" ]; then
+    #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+    #     LIB_DEST="/clang64/lib"
+    #     INC_DEST="/clang64/include"
     # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
     #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
     #     LIB_DEST="/clangarm64/lib"
     #     INC_DEST="/clangarm64/include"
-    fi
+    # fi
 
     # Check if python3 installed on Windows
     if command -v python3 &> /dev/null; then

--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -44,16 +44,26 @@ elif [ "$SK_OS" = "linux" ]; then
         echo "For Python support: Please install python3, then run this script again."
     fi
 elif [ "$SK_OS" = "win64" ]; then
-    LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
-    WIN_OUT_DIR="${WINDIR}/System32"
-    LIB_DEST="/mingw64/lib"
-    INC_DEST="/mingw64/include"
+    # WIN_OUT_DIR="${WINDIR}/System32"
+    if [ "$MSYSTEM" = "MINGW64" ]; then
+        LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+        LIB_DEST="/mingw64/lib"
+        INC_DEST="/mingw64/include"
+    elif [ "$MSYSTEM" = "CLANG64" ]; then
+        LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+        LIB_DEST="/clang64/lib"
+        INC_DEST="/clang64/include"
+    # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+    #     LIB_DEST="/clangarm64/lib"
+    #     INC_DEST="/clangarm64/include"
+    fi
 
-    # Check if python3 installed on Windows (mingw64)
+    # Check if python3 installed on Windows
     if command -v python3 &> /dev/null; then
         HAS_PYTHON3=true
     else
-        echo "For Python support: Please install python3 using "pacman -S mingw-w64-x86_64-python", then run this script again."
+        echo "For Python support: Please install python3, then run this script again."
     fi
 else
     echo "Unable to detect operating system..."
@@ -73,8 +83,14 @@ if [ "$HAS_PYTHON3" = true ]; then
         # Linux/WSL Python3 global install path
         PYTHON_LIB="/usr/lib/python${PYTHON_VERSION}"
     elif [ "$SK_OS" = "win64" ]; then
-        # Windows (mingw64) Python3 global install path
-        PYTHON_LIB="/mingw64/lib/python${PYTHON_VERSION}"
+        # Windows Python3 global install path
+        if [ "$MSYSTEM" = "MINGW64" ]; then
+            PYTHON_LIB="/mingw64/lib/python${PYTHON_VERSION}"
+        elif [ "$MSYSTEM" = "CLANG64" ]; then
+            PYTHON_LIB="/clang64/lib/python${PYTHON_VERSION}"
+        # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+        #     PYTHON_LIB="/clangarm64/lib/python${PYTHON_VERSION}"
+        fi
     fi
 fi
 
@@ -143,9 +159,6 @@ if [ "$SK_OS" = "linux" ]; then
 elif [ "$SK_OS" = "macos" ]; then
     echo "Setting library location"
     sudo install_name_tool -id /usr/local/lib/libSplashKit.dylib /usr/local/lib/libSplashKit.dylib
-elif [ "$SK_OS" = "win64" ]; then
-    echo "Installing required dependencies"
-    pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
 fi
 
 echo "Testing install"

--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -5,7 +5,7 @@ APP_PATH=`cd "$APP_PATH"; pwd`
 
 SKM_PATH=`cd "$APP_PATH/../.."; pwd`
 
-PYTHON_VERSION=`python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major + "." + minor);'`
+HAS_PYTHON3=false
 
 source "${SKM_PATH}/tools/set_sk_env_vars.sh"
 
@@ -26,45 +26,56 @@ if [ "$SK_OS" = "macos" ]; then
     LIB_DEST="/usr/local/lib"
     INC_DEST="/usr/local/include"
 
-    # macOS Python3 global install
-    if command -v python3 &> /dev/null; then
-        if command -v brew &> /dev/null; then
-            PYTHON_LIB="/opt/homebrew/lib/python${PYTHON_VERSION}/site-packages"
-        else
-            echo "Homebrew is not installed. Install homebrew and python3 using homebrew and run this script again"
-        fi
+    # Check if python3 installed on macOS
+    if command -v python3 &> /dev/null && command -v brew &> /dev/null; then
+        HAS_PYTHON3=true
     else
-        echo "Python is not installed. Install python3 using homebrew and run this script again."
+        echo "For Python support: Please install python3 using brew (Homebrew), then run this script again."
     fi
-
 elif [ "$SK_OS" = "linux" ]; then
     LIB_FILE="${SKM_PATH}/lib/linux/libSplashKit.so"
     LIB_DEST="/usr/local/lib"
     INC_DEST="/usr/local/include"
 
-    # Linux/WSL Python3 global install
+    # Check if python3 installed on Linux/WSL
     if command -v python3 &> /dev/null; then
-        PYTHON_LIB="/usr/lib/python${PYTHON_VERSION}"
+        HAS_PYTHON3=true
     else
-        echo "Python is not installed. Install python3 and run this script again."
+        echo "For Python support: Please install python3, then run this script again."
     fi
-
 elif [ "$SK_OS" = "win64" ]; then
     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
     WIN_OUT_DIR="${WINDIR}/System32"
     LIB_DEST="/mingw64/lib"
     INC_DEST="/mingw64/include"
 
-    # Windows (mingw64) Python3 global install
+    # Check if python3 installed on Windows (mingw64)
     if command -v python3 &> /dev/null; then
-        PYTHON_LIB="/mingw64/lib/python${PYTHON_VERSION}"
+        HAS_PYTHON3=true
     else
-        echo "Python is not installed. Install python3 and run this script again."
+        echo "For Python support: Please install python3 using "pacman -S mingw-w64-x86_64-python", then run this script again."
     fi
-
 else
     echo "Unable to detect operating system..."
     exit 1
+fi
+
+# Get python3 directory for each OS if installed
+if [ "$HAS_PYTHON3" = true ]; then
+    PYTHON_VERSION=`python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major + "." + minor);'`
+    
+    echo "Detecting python3 version to set global path"
+
+    if [ "$SK_OS" = "macos" ]; then
+        # macOS Python3 global install path
+        PYTHON_LIB="/opt/homebrew/lib/python${PYTHON_VERSION}/site-packages"
+    elif [ "$SK_OS" = "linux" ]; then
+        # Linux/WSL Python3 global install path
+        PYTHON_LIB="/usr/lib/python${PYTHON_VERSION}"
+    elif [ "$SK_OS" = "win64" ]; then
+        # Windows (mingw64) Python3 global install path
+        PYTHON_LIB="/mingw64/lib/python${PYTHON_VERSION}"
+    fi
 fi
 
 if [ ! -d "${LIB_DEST}" ]; then
@@ -86,19 +97,10 @@ if [ ! -d "${INC_DEST}/splashkit" ]; then
 fi
 
 echo "Copying files to "${LIB_DEST}""
-# Copy all library files for mingw/msys2
-if [ "$SK_OS" = "win64" ]; then
-    $PRIVILEGED cp "${SKM_PATH}/lib/win64/"* "$LIB_DEST"
-    if [ ! $? -eq 0 ]; then
-        echo "Failed to copy SplashKit library files to $LIB_DEST"
-        exit 1
-    fi
-else
-    $PRIVILEGED cp -f "$LIB_FILE" "$LIB_DEST"
-    if [ ! $? -eq 0 ]; then
-        echo "Failed to copy SplashKit library to $LIB_DEST"
-        exit 1
-    fi
+$PRIVILEGED cp -f "$LIB_FILE" "$LIB_DEST"
+if [ ! $? -eq 0 ]; then
+    echo "Failed to copy SplashKit library to $LIB_DEST"
+    exit 1
 fi
 
 echo "Copying files to ${INC_DEST}/splashkit"
@@ -115,11 +117,13 @@ if [ ! $? -eq 0 ]; then
 fi
 
 # Copy splashkit python file to global location
-echo "Copying splashkit.py to "${PYTHON_LIB}""
-$PRIVILEGED cp "${SKM_PATH}/python3/splashkit.py" "${PYTHON_LIB}"
-if [ ! $? -eq 0 ]; then
-    echo "Failed to copy splashkit.py to ${PYTHON_LIB}"
-    exit 1
+if [ "$HAS_PYTHON3" = true ]; then
+    echo "Copying splashkit.py to "${PYTHON_LIB}""
+    $PRIVILEGED cp "${SKM_PATH}/python3/splashkit.py" "${PYTHON_LIB}"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to copy splashkit.py to ${PYTHON_LIB}"
+        exit 1
+    fi
 fi
 
 # We cant install but it should be on the path anyway...
@@ -139,6 +143,9 @@ if [ "$SK_OS" = "linux" ]; then
 elif [ "$SK_OS" = "macos" ]; then
     echo "Setting library location"
     sudo install_name_tool -id /usr/local/lib/libSplashKit.dylib /usr/local/lib/libSplashKit.dylib
+elif [ "$SK_OS" = "win64" ]; then
+    echo "Installing required dependencies"
+    pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
 fi
 
 echo "Testing install"

--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -86,11 +86,19 @@ if [ ! -d "${INC_DEST}/splashkit" ]; then
 fi
 
 echo "Copying files to "${LIB_DEST}""
-
-$PRIVILEGED cp -f "$LIB_FILE" "$LIB_DEST"
-if [ ! $? -eq 0 ]; then
-    echo "Failed to copy SplashKit library to $LIB_DEST"
-    exit 1
+# Copy all library files for mingw/msys2
+if [ "$SK_OS" = "win64" ]; then
+    $PRIVILEGED cp "${SKM_PATH}/lib/win64/"* "$LIB_DEST"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to copy SplashKit library files to $LIB_DEST"
+        exit 1
+    fi
+else
+    $PRIVILEGED cp -f "$LIB_FILE" "$LIB_DEST"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to copy SplashKit library to $LIB_DEST"
+        exit 1
+    fi
 fi
 
 echo "Copying files to ${INC_DEST}/splashkit"

--- a/global/install/skm_global_install.sh
+++ b/global/install/skm_global_install.sh
@@ -155,7 +155,12 @@ fi
 
 if [ "$SK_OS" = "linux" ]; then
     echo "Updating library config cache"
-    $PRIVILEGED ldconfig /usr/local/lib
+    # Add /usr/local/lib to ld search paths using conf file
+    touch "${SKM_PATH}/linux/splashkit.conf"
+    echo "/usr/local/lib" >> "${SKM_PATH}/linux/splashkit.conf"
+    $PRIVILEGED cp -n "${SKM_PATH}/linux/splashkit.conf /etc/ld.so.conf.d/splashkit.conf"
+    rm "${SKM_PATH}/linux/splashkit.conf"
+    $PRIVILEGED ldconfig
 elif [ "$SK_OS" = "macos" ]; then
     echo "Setting library location"
     sudo install_name_tool -id /usr/local/lib/libSplashKit.dylib /usr/local/lib/libSplashKit.dylib

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -54,15 +54,18 @@ fi
 export PATH="$INSTALL_PATH:$PATH"
 
 if [[ `uname` = MINGW64* ]] || [[ `uname` = MSYS* ]]; then
+    SHELL_PATH="/mingw64/bin"
+
+    # Section below commented out for further testing
     # Detect MSYS2 shell
-    SHELL_PATH=""
-    if [ "$MSYSTEM" = "MINGW64" ]; then
-        SHELL_PATH="/mingw64/bin"
-    elif [ "$MSYSTEM" = "CLANG64" ]; then
-        SHELL_PATH="/clang64/bin"
-    elif [ "$MSYSTEM" = "CLANGARM64" ]; then
-        SHELL_PATH="/clangarm64/bin"
-    fi
+    # SHELL_PATH=""
+    # if [ "$MSYSTEM" = "MINGW64" ]; then
+    #     SHELL_PATH="/mingw64/bin"
+    # elif [ "$MSYSTEM" = "CLANG64" ]; then
+    #     SHELL_PATH="/clang64/bin"
+    # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    #     SHELL_PATH="/clangarm64/bin"
+    # fi
     
     # List of PATHS added in splashkit install
     SK_PATHS=("`cd $SHELL_PATH; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -54,21 +54,25 @@ fi
 export PATH="$INSTALL_PATH:$PATH"
 
 if [[ `uname` = MINGW64* ]] || [[ `uname` = MSYS* ]]; then
-    #Export to path -- for current terminal
-    export PATH="$HOME/.splashkit/lib/win64:$PATH"
-    export PATH="$HOME/.splashkit:$PATH"
+    # List of PATHS added in splashkit install
+    SK_PATHS=("`cd /mingw64/bin; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")
+    
+    # Get Windows path and remove splashkit-added path elements
+    ORIGINAL_WIN_PATH=`powershell.exe -Command "[System.Environment]::GetEnvironmentVariable('PATH','User')"`
 
-    #Export path for new terminals
-    export ORIGINAL_PATH="$HOME/.splashkit/lib/win64:$ORIGINAL_PATH"
-    export ORIGINAL_PATH="$HOME/.splashkit:$ORIGINAL_PATH"
+    # Create string for splashKit paths
+    SK_PATHS_STR=""
+    for i in ${!SK_PATHS[@]}; do
+        SK_PATH="${SK_PATHS[$i]}"
+        SK_PATH="${SK_PATH////\\}"
+        SK_PATHS_STR+="$SK_PATH;"
+    done
 
-    #Export paths for mingw64 compilers
-    COMPILER_PATH="/mingw64/bin"
-    export PATH="$COMPILER_PATH:$PATH"
-    export ORIGINAL_PATH="$COMPILER_PATH:$ORIGINAL_PATH"
+    # Create string for new windows path with splashkit paths added
+    NEW_WIN_PATH="$SK_PATHS_STR$ORIGINAL_WIN_PATH"
 
-    # Set path
-    setx PATH "$ORIGINAL_PATH"
+    # Set updated Windows path
+    powershell.exe -Command "[System.Environment]::SetEnvironmentVariable('PATH',\"$NEW_WIN_PATH\",'User')"
 fi
 
 if [[ `uname` = Linux ]]; then

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -54,8 +54,18 @@ fi
 export PATH="$INSTALL_PATH:$PATH"
 
 if [[ `uname` = MINGW64* ]] || [[ `uname` = MSYS* ]]; then
+    # Detect MSYS2 shell
+    SHELL_PATH=""
+    if [ "$MSYSTEM" = "MINGW64" ]; then
+        SHELL_PATH="/mingw64/bin"
+    elif [ "$MSYSTEM" = "CLANG64" ]; then
+        SHELL_PATH="/clang64/bin"
+    elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+        SHELL_PATH="/clangarm64/bin"
+    fi
+    
     # List of PATHS added in splashkit install
-    SK_PATHS=("`cd /mingw64/bin; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")
+    SK_PATHS=("`cd $SHELL_PATH; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")
     
     # Get Windows path and remove splashkit-added path elements
     ORIGINAL_WIN_PATH=`powershell.exe -Command "[System.Environment]::GetEnvironmentVariable('PATH','User')"`
@@ -73,6 +83,9 @@ if [[ `uname` = MINGW64* ]] || [[ `uname` = MSYS* ]]; then
 
     # Set updated Windows path
     powershell.exe -Command "[System.Environment]::SetEnvironmentVariable('PATH',\"$NEW_WIN_PATH\",'User')"
+
+    echo "Run the following to install the required pacman packages for splashkit:"
+    echo "${bold}skm windows install${normal}"
 fi
 
 if [[ `uname` = Linux ]]; then

--- a/python3/help.sh
+++ b/python3/help.sh
@@ -8,21 +8,11 @@ else
 
     echo "OVERVIEW: run python3 with SplashKit settings"
     echo
-    echo "USAGE: python3 [options] [input]"
+    echo "USAGE: skm python3 [options] [input]"
     echo 
     echo "Runs python3 with the required SplashKit settings and any additional options and input files."
     echo
-    echo "Example usage (${bold}with global install${normal}):"
-    echo "    Run a 'program.py' file using"
-    echo "    ${bold}python3 program.py${normal}"
-    echo
-    echo "    Run an interactive python3 REPL"
-    echo "    ${bold}python3${normal}"
-    echo 
-    echo "    Output options for python3"
-    echo "    ${bold}python3 --help${normal}"
-    echo
-    echo "Example usage (${bold}without global install${normal}):"
+    echo "Example usage:"
     echo "    Run a 'program.py' file using"
     echo "    ${bold}skm python3 program.py${normal}"
     echo
@@ -31,6 +21,8 @@ else
     echo 
     echo "    Output options for python3"
     echo "    ${bold}skm python3 --help${normal}"
+    echo
+    echo "Note: If you have run ${bold}skm global install${normal}), you can run SplashKit python code with the regular python commands (without \"skm\")"
 
 fi
 

--- a/python3/help.sh
+++ b/python3/help.sh
@@ -8,11 +8,21 @@ else
 
     echo "OVERVIEW: run python3 with SplashKit settings"
     echo
-    echo "USAGE: skm python3 [options] [input]"
+    echo "USAGE: python3 [options] [input]"
     echo 
     echo "Runs python3 with the required SplashKit settings and any additional options and input files."
     echo
-    echo "Example usage:"
+    echo "Example usage (${bold}with global install${normal}):"
+    echo "    Run a 'program.py' file using"
+    echo "    ${bold}python3 program.py${normal}"
+    echo
+    echo "    Run an interactive python3 REPL"
+    echo "    ${bold}python3${normal}"
+    echo 
+    echo "    Output options for python3"
+    echo "    ${bold}python3 --help${normal}"
+    echo
+    echo "Example usage (${bold}without global install${normal}):"
     echo "    Run a 'program.py' file using"
     echo "    ${bold}skm python3 program.py${normal}"
     echo
@@ -21,5 +31,6 @@ else
     echo 
     echo "    Output options for python3"
     echo "    ${bold}skm python3 --help${normal}"
+
 fi
 

--- a/python3/splashkit.py
+++ b/python3/splashkit.py
@@ -3,18 +3,44 @@ from enum import Enum
 from platform import system
 import os
 
+# default with no path
+lib_path = ""
+
 if system() == 'Darwin':
-  # macOS uses .dylib extension
-  cdll.LoadLibrary("/usr/local/lib/libSplashKit.dylib")
-  sklib = CDLL("/usr/local/lib/libSplashKit.dylib")
+    # macOS uses .dylib extension
+    file_extension = ".dylib"
+    file_name = "libSplashKit"
+    # find path to use -> ["global/path", "splashkit/path"]
+    paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
+    for path in paths:
+        if (os.path.isdir(path)):
+            lib_path = path
+            break
 elif system() == 'Linux':
-  # Linux uses .so extension
-  cdll.LoadLibrary("libSplashKit.so")
-  sklib = CDLL("libSplashKit.so")
+    # Linux uses .so extension
+    file_extension = ".so"
+    file_name = "libSplashKit"
+    # using default lib_path for now
+    # # find path to use -> ["global/path", "splashkit/path"]
+    # paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
+    # for path in paths:
+    #     if (os.path.isdir(path)):
+    #         lib_path = path
+    #         break
 else:
-  # Windows uses .dll extension:
-  cdll.LoadLibrary("C:\msys64\home\\" + os.getlogin() + "\.splashkit\lib\win64\SplashKit.dll")
-  sklib = CDLL("splashkit.dll")
+    # Windows uses .dll extension:
+    file_extension = ".dll"
+    file_name = "SplashKit"
+    # find path to use -> ["global/path", "splashkit/path"]
+    paths = ["C:/msys64/mingw64/lib/", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/"]
+    for path in paths:
+        if (os.path.isdir(path)):
+            lib_path = path
+            break
+
+# load the library
+cdll.LoadLibrary(lib_path + file_name + file_extension)
+sklib = CDLL(lib_path + file_name + file_extension)
 
 class _sklib_string(Structure):
     _fields_ = [

--- a/python3/splashkit.py
+++ b/python3/splashkit.py
@@ -2,6 +2,7 @@ from ctypes import *
 from enum import Enum
 from platform import system
 import os
+import sys
 
 search_paths = []
 
@@ -13,7 +14,7 @@ elif system() == 'Linux':
     search_paths = ["/usr/local/lib/libSplashKit.so", os.path.expanduser("~") + "/.splashkit/lib/linux/libSplashKit.so"]
 else:
     # Windows uses .dll extension
-    search_paths = ["C:/msys64/mingw64/lib/SplashKit.dll", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/SplashKit.dll"]
+    search_paths = [sys.prefix + "/lib/SplashKit.dll", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/SplashKit.dll"]
 
 # find path to use -> format above is: ["global/path", ".splashkit/path"]
 for path in search_paths:

--- a/python3/splashkit.py
+++ b/python3/splashkit.py
@@ -1,19 +1,20 @@
 from ctypes import *
 from enum import Enum
 from platform import system
+import os
 
 if system() == 'Darwin':
   # macOS uses .dylib extension
-  cdll.LoadLibrary("libSplashKit.dylib")
-  sklib = CDLL("libsplashkit.dylib")
+  cdll.LoadLibrary("/usr/local/lib/libSplashKit.dylib")
+  sklib = CDLL("/usr/local/lib/libSplashKit.dylib")
 elif system() == 'Linux':
   # Linux uses .so extension
   cdll.LoadLibrary("libSplashKit.so")
   sklib = CDLL("libSplashKit.so")
 else:
   # Windows uses .dll extension:
-  cdll.LoadLibrary("libSplashKit.dll")
-  sklib = CDLL("libsplashkit.dll")
+  cdll.LoadLibrary("C:\msys64\home\\" + os.getlogin() + "\.splashkit\lib\win64\SplashKit.dll")
+  sklib = CDLL("splashkit.dll")
 
 class _sklib_string(Structure):
     _fields_ = [
@@ -1223,7 +1224,7 @@ def __skadapter__update_from_vector_bool(v, __skreturn):
 
     sklib.__sklib__free__sklib_vector_bool(v)
 def __skadapter__to_sklib_string(s):
-    return _sklib_string(s)
+    return _sklib_string(s.replace('\r',''))
 
 sklib.__sklib__free__sklib_string.argtypes = [ _sklib_string ]
 sklib.__sklib__free__sklib_string.restype = None
@@ -4092,11 +4093,11 @@ def length_of ( text ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skreturn = sklib.__sklib__length_of__string_ref(__skparam__text)
     return __skadapter__to_int(__skreturn)
-def replace_all ( text, substr, newText ):
+def replace_all ( text, substr, replacement ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skparam__substr = __skadapter__to_sklib_string(substr)
-    __skparam__newText = __skadapter__to_sklib_string(newtext)
-    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText)
+    __skparam__replacement = __skadapter__to_sklib_string(replacement)
+    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__replacement)
     return __skadapter__to_string(__skreturn)
 def split ( text, delimiter ):
     __skparam__text = __skadapter__to_sklib_string(text)

--- a/python3/splashkit.py
+++ b/python3/splashkit.py
@@ -3,44 +3,25 @@ from enum import Enum
 from platform import system
 import os
 
-# default with no path
-lib_path = ""
+search_paths = []
 
 if system() == 'Darwin':
     # macOS uses .dylib extension
-    file_extension = ".dylib"
-    file_name = "libSplashKit"
-    # find path to use -> ["global/path", "splashkit/path"]
-    paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
-    for path in paths:
-        if (os.path.isdir(path)):
-            lib_path = path
-            break
+    search_paths = ["/usr/local/lib/libSplashKit.dylib", os.path.expanduser("~") + "/.splashkit/lib/macos/libSplashKit.dylib"]
 elif system() == 'Linux':
     # Linux uses .so extension
-    file_extension = ".so"
-    file_name = "libSplashKit"
-    # using default lib_path for now
-    # # find path to use -> ["global/path", "splashkit/path"]
-    # paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
-    # for path in paths:
-    #     if (os.path.isdir(path)):
-    #         lib_path = path
-    #         break
+    search_paths = ["/usr/local/lib/libSplashKit.so", os.path.expanduser("~") + "/.splashkit/lib/linux/libSplashKit.so"]
 else:
-    # Windows uses .dll extension:
-    file_extension = ".dll"
-    file_name = "SplashKit"
-    # find path to use -> ["global/path", "splashkit/path"]
-    paths = ["C:/msys64/mingw64/lib/", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/"]
-    for path in paths:
-        if (os.path.isdir(path)):
-            lib_path = path
-            break
+    # Windows uses .dll extension
+    search_paths = ["C:/msys64/mingw64/lib/SplashKit.dll", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/SplashKit.dll"]
 
-# load the library
-cdll.LoadLibrary(lib_path + file_name + file_extension)
-sklib = CDLL(lib_path + file_name + file_extension)
+# find path to use -> format above is: ["global/path", ".splashkit/path"]
+for path in search_paths:
+    if (os.path.isfile(path)):
+        # load the library
+        cdll.LoadLibrary(path)
+        sklib = CDLL(path)
+        break
 
 class _sklib_string(Structure):
     _fields_ = [
@@ -4119,11 +4100,11 @@ def length_of ( text ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skreturn = sklib.__sklib__length_of__string_ref(__skparam__text)
     return __skadapter__to_int(__skreturn)
-def replace_all ( text, substr, replacement ):
+def replace_all ( text, substr, newText ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skparam__substr = __skadapter__to_sklib_string(substr)
-    __skparam__replacement = __skadapter__to_sklib_string(replacement)
-    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__replacement)
+    __skparam__newText = __skadapter__to_sklib_string(newtext)
+    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText)
     return __skadapter__to_string(__skreturn)
 def split ( text, delimiter ):
     __skparam__text = __skadapter__to_sklib_string(text)

--- a/tools/set_sk_env_vars.sh
+++ b/tools/set_sk_env_vars.sh
@@ -7,9 +7,13 @@ if [ "`uname -o 2>>/dev/null`" = "Msys" ]; then
         exit 1
     elif [ "$MSYSTEM" = "MINGW64" ]; then
         export SK_OS="win64"
+    elif [ "$MSYSTEM" = "CLANG64" ]; then
+        export SK_OS="win64"
+    # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    #     export SK_OS="winARM"
     else
         echo "Unable to detect Windows version..."
-        echo "Please run in MinGW64 terminal"
+        # echo "Please run in MinGW64 terminal"
         exit 1
     fi
 elif [ `uname` = "Darwin" ]; then

--- a/uninstall/uninstall.sh
+++ b/uninstall/uninstall.sh
@@ -141,6 +141,25 @@ if [[ ${SHELL} = "/bin/zsh" ]] || [[ ${SHELL} = "/usr/bin/zsh" ]]; then
     fi
 fi
 
+# Remove splashkit paths from Windows User PATH if using Windows(MSYS2)
+if [ $SK_OS = "win64" ]; then
+    # List of PATHS added in splashkit install
+    SK_PATHS=("`cd /mingw64/bin; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")
+
+    # Update paths in SK_PATHS to replace / with \
+    for i in ${!SK_PATHS[@]}; do
+        SK_PATH="${SK_PATHS[$i]}"
+        SK_PATH="${SK_PATH////\\}"
+        SK_PATHS[$i]=$SK_PATH
+    done
+
+    # Get Windows path and remove splashkit-added path elements
+    ORIGINAL_WIN_PATH=`powershell.exe -Command "([System.Environment]::GetEnvironmentVariable('PATH','User').Split(';') | Where-Object { (\\$_ -ne '${SK_PATHS[0]}' -and \\$_ -ne '${SK_PATHS[1]}' -and \\$_ -ne '${SK_PATHS[2]}') }) -join ';'"`
+
+    # Set updated Windows path
+    powershell.exe -Command "[System.Environment]::SetEnvironmentVariable('PATH',\"$ORIGINAL_WIN_PATH\",'User')"
+fi
+
 # Remove .splashkit folder
 echo "Removing .splashkit folder from "${INSTALL_PATH}""
 rm -rf ${INSTALL_PATH}

--- a/uninstall/uninstall.sh
+++ b/uninstall/uninstall.sh
@@ -44,19 +44,24 @@ elif [ "$SK_OS" = "linux" ]; then
     fi
 elif [ "$SK_OS" = "win64" ]; then
     # WIN_OUT_DIR="${WINDIR}/System32"
-    if [ "$MSYSTEM" = "MINGW64" ]; then
         LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
         LIB_DEST="/mingw64/lib"
         INC_DEST="/mingw64/include"
-    elif [ "$MSYSTEM" = "CLANG64" ]; then
-        LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
-        LIB_DEST="/clang64/lib"
-        INC_DEST="/clang64/include"
+
+    # Section below commented out for further testing
+    # if [ "$MSYSTEM" = "MINGW64" ]; then
+    #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+    #     LIB_DEST="/mingw64/lib"
+    #     INC_DEST="/mingw64/include"
+    # elif [ "$MSYSTEM" = "CLANG64" ]; then
+    #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
+    #     LIB_DEST="/clang64/lib"
+    #     INC_DEST="/clang64/include"
     # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
     #     LIB_FILE="${SKM_PATH}/lib/win64/SplashKit.dll"
     #     LIB_DEST="/clangarm64/lib"
     #     INC_DEST="/clangarm64/include"
-    fi
+    # fi
 
     # Check if python3 installed on Windows (mingw64)
     if command -v python3 &> /dev/null; then
@@ -169,15 +174,18 @@ fi
 
 # Remove splashkit paths from Windows User PATH if using Windows(MSYS2)
 if [ $SK_OS = "win64" ]; then
+    SHELL_PATH="/mingw64/bin"
+
+    # Section below commented out for further testing
     # Detect MSYS2 shell
-    SHELL_PATH=""
-    if [ "$MSYSTEM" = "MINGW64" ]; then
-        SHELL_PATH="/mingw64/bin"
-    elif [ "$MSYSTEM" = "CLANG64" ]; then
-        SHELL_PATH="/clang64/bin"
-    elif [ "$MSYSTEM" = "CLANGARM64" ]; then
-        SHELL_PATH="/clangarm64/bin"
-    fi
+    # SHELL_PATH=""
+    # if [ "$MSYSTEM" = "MINGW64" ]; then
+    #     SHELL_PATH="/mingw64/bin"
+    # elif [ "$MSYSTEM" = "CLANG64" ]; then
+    #     SHELL_PATH="/clang64/bin"
+    # elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    #     SHELL_PATH="/clangarm64/bin"
+    # fi
     
     # List of PATHS added in splashkit install
     SK_PATHS=("`cd $SHELL_PATH; pwd -W`" "`cd ~/.splashkit; pwd -W`" "`cd ~/.splashkit/lib/win64; pwd -W`")

--- a/uninstall/uninstall.sh
+++ b/uninstall/uninstall.sh
@@ -98,6 +98,12 @@ if [ -f "${LIB_FILE}" ]; then
     fi
 fi
 
+# Remove conf file to link libraries added to /usr/local/lib directory
+if [ "$SK_OS" = "linux" ]; then
+    echo "Removing splashkit.conf file from /etc/ld.so.conf.d/"
+    $PRIVILEGED rm -f "/etc/ld.so.conf.d/splashkit.conf"
+fi
+
 # Get python3 directory for each OS if installed
 if [ "$HAS_PYTHON3" = true ]; then
     PYTHON_VERSION=`python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major + "." + minor);'`

--- a/uninstall/uninstall.sh
+++ b/uninstall/uninstall.sh
@@ -6,4 +6,141 @@ APP_PATH=`cd "$APP_PATH"; pwd`
 HOME_PATH=~
 INSTALL_PATH="${HOME_PATH}/.splashkit"
 
+SKM_PATH=`cd "$APP_PATH/.."; pwd`
+
+source "${SKM_PATH}/tools/set_sk_env_vars.sh"
+
+echo "Attempting to uninstall SplashKit libraries"
+echo "This may require root access, please enter your password when prompted."
+echo
+
+if [ "$IS_WINDOWS" = true ]; then
+    PRIVILEGED=""
+else
+    PRIVILEGED="sudo"
+fi
+
+PYTHON_VERSION=`python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major + "." + minor);'`
+
+# Get directories for each OS
+echo "Detecting operating system..."
+if [ "$SK_OS" = "macos" ]; then
+    LIB_FILE="/usr/local/lib/libSplashKit.dylib"
+    LIB_DEST="/usr/local/lib"
+    INC_DEST="/usr/local/include"
+
+    # macOS Python3 global install
+    if command -v python3 &> /dev/null && command -v brew &> /dev/null; then
+        PYTHON_LIB="/opt/homebrew/lib/python${PYTHON_VERSION}/site-packages"
+    fi
+
+elif [ "$SK_OS" = "linux" ]; then
+    LIB_FILE="/usr/local/lib/libSplashKit.so"
+    LIB_DEST="/usr/local/lib"
+    INC_DEST="/usr/local/include"
+
+    # Linux/WSL Python3 global install
+    if command -v python3 &> /dev/null; then
+        PYTHON_LIB="/usr/lib/python${PYTHON_VERSION}"
+    fi
+
+elif [ "$SK_OS" = "win64" ]; then
+    LIB_FILE="/mingw64/lib/SplashKit.dll"
+    LIB_SRC="${SKM_PATH}/lib/win64"
+    LIB_DEST="/mingw64/lib"
+    INC_DEST="/mingw64/include"
+
+    # Windows (mingw64) Python3 global install
+    if command -v python3 &> /dev/null; then
+        PYTHON_LIB="/mingw64/lib/python${PYTHON_VERSION}"
+    fi
+
+else
+    echo "Unable to detect operating system..."
+    exit 1
+fi
+
+# Remove global library include files in splashkit folder (and folder itself)
+if [ -d "${INC_DEST}/splashkit" ]; then
+    echo "Remove directory ${INC_DEST}/splashkit"
+    $PRIVILEGED rm -rf "${INC_DEST}/splashkit"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to remove directory ${INC_DEST}/splashkit"
+        exit 1
+    fi
+fi
+
+# Remove splashkit header file
+if [ -f "${INC_DEST}/splashkit.h" ]; then
+    echo "Removing splashkit header file from "${LIB_DEST}""
+    $PRIVILEGED rm -f "${INC_DEST}/splashkit.h"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to remove SplashKit header from ${INC_DEST}"
+        exit 1
+    fi
+fi
+
+# Remove splashkit library file
+if [ -f "${LIB_FILE}" ]; then
+    if [ "$SK_OS" = "win64" ]; then
+        # Remove all splashkit related library files for mingw/msys2
+        echo "Removing splashkit files from "${LIB_DEST}""
+        cd $LIB_SRC
+        find . -type f -exec rm -rf $LIB_DEST/{} \;
+        if [ ! $? -eq 0 ]; then
+            echo "Failed to remove SplashKit library files from $LIB_DEST"
+            exit 1
+        fi
+    else
+        # Remove splashkit library file on macos and linux
+        echo "Removing splashkit file from "${LIB_DEST}""
+        $PRIVILEGED rm -f "$LIB_FILE"
+        if [ ! $? -eq 0 ]; then
+            echo "Failed to remove SplashKit library from $LIB_DEST"
+            exit 1
+        fi
+    fi
+fi
+
+# Remove splashkit python file from global location if python3 is installed
+if [ -f "${PYTHON_LIB}/splashkit.py" ]; then
+    echo "Removing splashkit.py to "${PYTHON_LIB}""
+    $PRIVILEGED rm -f "${PYTHON_LIB}/splashkit.py"
+    if [ ! $? -eq 0 ]; then
+        echo "Failed to remove splashkit.py from ${PYTHON_LIB}"
+        exit 1
+    fi
+fi
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Remove splashkit path from .bashrc if using bash
+if [[ ${SHELL} = "/bin/bash" ]] || [ ${SHELL} = "/usr/bin/bash" -a `uname` = Linux ] ; then
+    echo "Removing ${bold}export PATH=\"$INSTALL_PATH:\$PATH\"${normal} from ~/.bashrc"
+    if [ $SK_OS = "macos" ]; then
+        sed -i '' "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.bashrc
+    else
+        sed -i "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.bashrc
+    fi
+    echo "Removing ${bold}export PATH=\"$INSTALL_PATH:\$PATH\"${normal} from ~/.bash_profile"
+    if [ $SK_OS = "macos" ]; then
+        sed -i '' "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.bash_profile
+    else
+        sed -i "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.bash_profile
+    fi
+fi
+
+# Remove splashkit path from .zshrc if using zsh
+if [[ ${SHELL} = "/bin/zsh" ]] || [[ ${SHELL} = "/usr/bin/zsh" ]]; then
+    echo "Removing ${bold}export PATH=\"$INSTALL_PATH:\$PATH\"${normal} from ~/.zshrc"
+    if [ $SK_OS = "macos" ]; then
+        sed -i '' "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.zshrc
+    else
+        sed -i "\|export PATH=\"$INSTALL_PATH:\$PATH\"|d" ~/.zshrc
+    fi
+fi
+
+# Remove .splashkit folder
+echo "Removing .splashkit folder from "${INSTALL_PATH}""
 rm -rf ${INSTALL_PATH}

--- a/windows/help.sh
+++ b/windows/help.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ "$1" = "-s" ] ; then
+    echo "    windows      Run windows distribution specific commands - namely 'skm windows install'"
+else
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+
+    echo "OVERVIEW: skm windows commands"
+    echo
+    echo "USAGE: skm windows install [--no-os-detect]"
+    echo 
+    echo "Perform necessary installation steps to build the SplashKit library locally. This will attempt to install the necessary components, or will provide instructions to do this manually."
+    echo
+    echo "Options:"
+    echo "  --no-os-detect  Flag to bypass OS detection, in case OS not detected correctly"
+    echo
+    echo "Example usage:"
+    echo "    Run the install scripts for SphasKit on windows."
+    echo "    ${bold}skm windows install${normal}"
+fi
+

--- a/windows/install/install.sh
+++ b/windows/install/install.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+SKM_PATH=`cd "$APP_PATH/../.."; pwd`
+
+# # Suppress the splashkit not found error (we're installing splashkit)
+# mkdir -p "$SKM_PATH/lib/linux"
+
+source "${SKM_PATH}/tools/set_sk_env_vars.sh"
+
+if [ "$SK_OS" = "win64" ]; then
+  : # All good - no op and continue
+elif [ "$SK_OS" = "macos" ] || [ "$SK_OS" = "linux" ] || ( echo "${*}" | grep '\-\-no-os-detect' ); then
+  echo "Windows install only available on Windows"
+  exit 1
+else
+    echo "Unable to detect operating system..."
+    exit 1
+fi
+
+${APP_PATH}/install_deps.sh
+
+
+# Libary building to come later
+
+# echo "Configuring SplashKit"
+# cd "${SKM_PATH}/source"
+# pwd
+# cmake .
+# if [ $? -ne 0 ]; then
+#   echo "Configuration failed"
+#   exit $?
+# fi
+
+# echo "Compiling SplashKit..."
+# make
+# if [ $? -ne 0 ]; then
+#   echo "Compilation failed"
+#   exit $?
+# fi
+
+# echo "Installing compiled SplashKit library..."
+# make install
+# if [ $? -ne 0 ]; then
+#   echo "Install failed"
+#   exit $?
+# fi
+
+# echo "SplashKit Installed"
+
+echo "SplashKit Dependencies Installed"

--- a/windows/install/install_deps.sh
+++ b/windows/install/install_deps.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+export DISTRO_ID="UNKNOWN"
+export DISTRO_VERSION="UNKNOWN"
+
+to_upper () {
+  echo $@ | tr [a-z] [A-Z]
+}
+
+detect_msys2_shell () {
+    if [ "$MSYSTEM" = "MINGW64" || "$MSYSTEM" = "CLANG64" || "$MSYSTEM" = "CLANGARM64" ]; then
+    	export DISTRO_ID=$MSYSTEM
+    else
+        echo "Unable to detect Windows version..."
+        echo "Please run in CLANG terminal"
+    fi
+}
+
+install_deps () {
+  case $1 in
+	MINGW64 )
+	  echo Installing depencies with $1 method
+	  echo You are about to install the dependencies using the following command:
+	  echo   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
+	  pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
+	  ;;
+  CLANG64 )
+	  echo Installing depencies with $1 method
+	  echo You are about to install the dependencies using the following command:
+	  pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-gcc mingw-w64-clang-x86_64-gdb mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-SDL2 mingw-w64-clang-x86_64-SDL2_gfx mingw-w64-clang-x86_64-SDL2_mixer mingw-w64-clang-x86_64-SDL2_image mingw-w64-clang-x86_64-SDL2_ttf mingw-w64-clang-x86_64-SDL2_net mingw-w64-clang-x86_64-civetweb
+	  ;;
+	# CLANGARM64 )
+	#   echo Installing depencies with $1 method
+	#   echo You are about to install the dependencies using the following command:
+	#   echo   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-clang-aarch64-clang mingw-w64-clang-aarch64-gcc mingw-w64-clang-aarch64-gdb mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-SDL2 mingw-w64-clang-aarch64-SDL2_gfx mingw-w64-clang-aarch64-SDL2_mixer mingw-w64-clang-aarch64-SDL2_image mingw-w64-clang-aarch64-SDL2_ttf mingw-w64-clang-aarch64-SDL2_net mingw-w64-clang-aarch64-civetweb
+	#   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
+	#   ;;
+	*)
+    echo Unable to install dependency;
+	  echo Going ahead with SplashKit install.
+	  echo If unsuccessful, ensure you have the following dependencies installed:
+	  echo   CMake, libpng, SDL2, SDL2_mixer, SDL2_gfx, SDL2_image, SDL_net, SDL2_ttf,
+	  echo   libmikmod, ncurses, bzip2, flac, vorbis, webp, freetype, clang
+
+	  ;;
+  esac
+}
+
+detect_msys2_shell
+install_deps $DISTRO_ID

--- a/windows/install/install_deps.sh
+++ b/windows/install/install_deps.sh
@@ -8,7 +8,7 @@ to_upper () {
 }
 
 detect_msys2_shell () {
-    if [ "$MSYSTEM" = "MINGW64" || "$MSYSTEM" = "CLANG64" || "$MSYSTEM" = "CLANGARM64" ]; then
+    if [ "$MSYSTEM" = "MINGW64" ] || [ "$MSYSTEM" = "CLANG64" ] || [ "$MSYSTEM" = "CLANGARM64" ]; then
     	export DISTRO_ID=$MSYSTEM
     else
         echo "Unable to detect Windows version..."
@@ -22,17 +22,17 @@ install_deps () {
 	  echo Installing depencies with $1 method
 	  echo You are about to install the dependencies using the following command:
 	  echo   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
-	  pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
+	  pacman -S --needed mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
 	  ;;
   CLANG64 )
 	  echo Installing depencies with $1 method
 	  echo You are about to install the dependencies using the following command:
-	  pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-gcc mingw-w64-clang-x86_64-gdb mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-SDL2 mingw-w64-clang-x86_64-SDL2_gfx mingw-w64-clang-x86_64-SDL2_mixer mingw-w64-clang-x86_64-SDL2_image mingw-w64-clang-x86_64-SDL2_ttf mingw-w64-clang-x86_64-SDL2_net mingw-w64-clang-x86_64-civetweb
+	  pacman -S --needed mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-gcc mingw-w64-clang-x86_64-gdb mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-SDL2 mingw-w64-clang-x86_64-SDL2_gfx mingw-w64-clang-x86_64-SDL2_mixer mingw-w64-clang-x86_64-SDL2_image mingw-w64-clang-x86_64-SDL2_ttf mingw-w64-clang-x86_64-SDL2_net mingw-w64-clang-x86_64-civetweb
 	  ;;
 	# CLANGARM64 )
 	#   echo Installing depencies with $1 method
 	#   echo You are about to install the dependencies using the following command:
-	#   echo   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-clang-aarch64-clang mingw-w64-clang-aarch64-gcc mingw-w64-clang-aarch64-gdb mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-SDL2 mingw-w64-clang-aarch64-SDL2_gfx mingw-w64-clang-aarch64-SDL2_mixer mingw-w64-clang-aarch64-SDL2_image mingw-w64-clang-aarch64-SDL2_ttf mingw-w64-clang-aarch64-SDL2_net mingw-w64-clang-aarch64-civetweb
+	#   echo   pacman -S --needed mingw-w64-clang-aarch64-clang mingw-w64-clang-aarch64-gcc mingw-w64-clang-aarch64-gdb mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-SDL2 mingw-w64-clang-aarch64-SDL2_gfx mingw-w64-clang-aarch64-SDL2_mixer mingw-w64-clang-aarch64-SDL2_image mingw-w64-clang-aarch64-SDL2_ttf mingw-w64-clang-aarch64-SDL2_net mingw-w64-clang-aarch64-civetweb
 	#   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
 	#   ;;
 	*)

--- a/windows/install/install_deps.sh
+++ b/windows/install/install_deps.sh
@@ -8,12 +8,18 @@ to_upper () {
 }
 
 detect_msys2_shell () {
-    if [ "$MSYSTEM" = "MINGW64" ] || [ "$MSYSTEM" = "CLANG64" ] || [ "$MSYSTEM" = "CLANGARM64" ]; then
-    	export DISTRO_ID=$MSYSTEM
-    else
-        echo "Unable to detect Windows version..."
-        echo "Please run in CLANG terminal"
-    fi
+	if command -v pacman &> /dev/null; then
+		# if [ "$MSYSTEM" = "MINGW64" ] || [ "$MSYSTEM" = "CLANG64" ] || [ "$MSYSTEM" = "CLANGARM64" ]; then
+		if [ "$MSYSTEM" = "MINGW64" ]; then
+			export DISTRO_ID=$MSYSTEM
+		else
+			echo "Unable to detect Windows version..."
+			echo "Please run in MINGW64 terminal"
+		fi
+	else
+		echo "Unable to install dependencies in Git Bash terminal"
+		echo "Please run in MINGW64 terminal"
+	fi
 }
 
 install_deps () {
@@ -21,13 +27,8 @@ install_deps () {
 	MINGW64 )
 	  echo Installing depencies with $1 method
 	  echo You are about to install the dependencies using the following command:
-	  echo   pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
-	  pacman -S --needed mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
-	  ;;
-  CLANG64 )
-	  echo Installing depencies with $1 method
-	  echo You are about to install the dependencies using the following command:
-	  pacman -S --needed mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-gcc mingw-w64-clang-x86_64-gdb mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-SDL2 mingw-w64-clang-x86_64-SDL2_gfx mingw-w64-clang-x86_64-SDL2_mixer mingw-w64-clang-x86_64-SDL2_image mingw-w64-clang-x86_64-SDL2_ttf mingw-w64-clang-x86_64-SDL2_net mingw-w64-clang-x86_64-civetweb
+	  echo   pacman -S --needed --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
+	  pacman -S --needed --disable-download-timeout mingw-w64-x86_64-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-civetweb
 	  ;;
 	# CLANGARM64 )
 	#   echo Installing depencies with $1 method

--- a/windows/windows.sh
+++ b/windows/windows.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+case $1 in
+    install)
+    "${APP_PATH}/install/install.sh" $*
+    ;;
+    *)
+    echo "Unknown option for skm windows. "    
+esac


### PR DESCRIPTION
# Description

This pull request updates the global install to copy the splashkit.py file to the global python location and updates the splashkit.py file generated from splashkit-core.

## Changes

1. Improved the python library loading in splashkit.py
2. Updated global install to copy **all** win64 dlls (not just `SplashKit.dll`) to /mingw64/lib as this was needed for the splashkit.py library loading to be able to use the global lib folder.
3. Updated the global install to copy the splashkit.py file to each OS' global python location (based on the current python3 version) to remove the need for `skm` when running python files.
4. Updated the python string to remove carriage returns that were causing strange behaviour with read_line (where string variables assigned with read_line would be overwritten by any strings joined after the variable when calling write_line - eg. write_line(name + "!") with a read_line input of "Olivia" would end up as "!livia"). Issue now fixed.
  Note: This issue was solved with the help of @Liquidscroll.
5. Updated the `skm help python3` command to include global commands.
6. Updated the `skm uninstall` command to remove global files and remove splashkit path from .bashrc/.bash_profile/.zshrc and remove splashkit paths from Windows User "Path" environment variable.
7. Updated the `skm-install.sh` script to add splashkit paths to Windows User "Path" environment variable using powershell. This reduces the extra "junk" paths that are added/duplicated to the User "Path" from the System "Path" with the previous format/code.
8. Updated the global install to fix issue with linux not searching /usr/local/lib directory. This adds a `splashkit.conf` file into "/etc/ld.so.conf.d/" folder. And the uninstall was updated to remove this file as well.

## How has this been tested?

**NOTE:** These changes can be tested by uninstalling splashkit (`skm uninstall`) and then run the following command instead of the usual command for this installation step:

```shell
bash <(curl -s https://raw.githubusercontent.com/omckeon/skm/fix/python-testing/install-scripts/skm-install.sh)
```

1. Copied file changes from this PR into each file inside `.splashkit` folder after running initial bash install script command, then ran global install command.
(Also tested using the command above.)
2. Ran test python program successfully (with `python3 program.py`).
3. Ran `skm uninstall` command to check files were changed/removed as expected (with success).

Note: Above steps were tested on Linux (Ubuntu and Manjaro), Windows (MSYS2 and WSL) and macOS.

### Global python testing results

Using the following test program code:

```python
from splashkit import *

write("What is your name: ")
name = read_line()

write_line(name + "!")
```

**Linux (Ubuntu)**:
![global-python-UbuntuLinux](https://github.com/user-attachments/assets/1175dbb1-5d6f-4cf5-ae6a-05174728c234)

**Linux (Manjaro)**:
![global-python-ManjaroLinux](https://github.com/user-attachments/assets/ec632a7c-37ce-4449-8df2-40a26ab48965)

**Windows (MSYS2)**:
![global-python-MSYS2](https://github.com/user-attachments/assets/915d5670-6b68-4dab-b01c-a929f2800af4)

**Windows (WSL)**:
![global-python-WSL](https://github.com/user-attachments/assets/6956e3e1-c7fb-4365-b338-9cccce63e209)

**macOS**:
<img width="372" alt="global-python-macOS" src="https://github.com/user-attachments/assets/261702ec-3526-4e20-864b-c3652e4b7657">