### PR TITLE
Fix install on OpenSUSE

### DIFF
--- a/linux/install/install.sh
+++ b/linux/install/install.sh
@@ -53,7 +53,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Compiling SplashKit..."
-make
+make -j$(nproc)
 if [ $? -ne 0 ]; then
   echo "Compilation failed"
   exit $?

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(SplashKit)
 include(ExternalProject)
+include(GNUInstallDirs)
 
 # Detect Windows and flag MSYS
 if (WIN32 OR MSYS OR MINGW)
@@ -199,7 +200,7 @@ ExternalProject_Add(
         else()
             set_target_properties(${lib} PROPERTIES
                 IMPORTED_LOCATION
-                    ${INSTALL_DIR}/lib/lib${lib}.a # lib prefix
+                    ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.a # lib prefix
             )
         endif()
         add_dependencies(${lib} llama_ext)


### PR DESCRIPTION
OpenSUSE uses a different directory for libraries (`lib64` instead of `lib`), so the install was failing when it tried to link against `libllama.a`. This change is untested on other systems but I see no indication as to why it should not work; still it should probably be tested.

Additionally, I have changed the make command in the Linux installer to use multiple jobs, which speeds up building llama.cpp dramatically. This change could potentially be made to the other installers as well.